### PR TITLE
Phase 1: AI分析削除 + パスワード文言（①権限の独立分）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ firebase-debug.log*
 playwright-report
 test-results
 
+# Local agent / editor config
+.claude/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -304,10 +304,6 @@ function isDeveloperCloudBackupSupported() {
   return typeof getDeveloperCloudBackupRuntimeWindow().showDirectoryPicker === 'function'
 }
 
-function serializeAnalysisExport(payload: unknown) {
-  return JSON.stringify(payload, null, 2)
-}
-
 function isDeveloperCloudBackupDirectoryHandle(value: unknown): value is DeveloperCloudBackupDirectoryHandle {
   if (!value || typeof value !== 'object') return false
   const record = value as Record<string, unknown>
@@ -500,46 +496,6 @@ function buildDeveloperRestoreModalState(currentSnapshot: WorkspaceSnapshot, res
       existsInCurrent: currentClassroomById.has(classroom.id),
       selected: true,
     })),
-  }
-}
-
-function buildWorkspaceAnalysisExport(snapshot: WorkspaceSnapshot) {
-  return {
-    exportedAt: snapshot.savedAt,
-    schemaVersion: snapshot.schemaVersion,
-    classroomCount: snapshot.classrooms.length,
-    userCount: snapshot.users.length,
-    classrooms: snapshot.classrooms.map((classroom) => {
-      const managerUser = snapshot.users.find((user) => user.id === classroom.managerUserId) ?? null
-      const payload = classroom.data
-      return {
-        classroomId: classroom.id,
-        classroomName: classroom.name,
-        contractStatus: classroom.contractStatus,
-        contractStartDate: classroom.contractStartDate,
-        contractEndDate: classroom.contractEndDate,
-        isTemporarilySuspended: Boolean(classroom.isTemporarilySuspended),
-        temporarySuspensionReason: classroom.temporarySuspensionReason ?? '',
-        managerUser: managerUser
-          ? {
-            id: managerUser.id,
-            name: managerUser.name,
-            email: managerUser.email,
-          }
-          : null,
-        counts: {
-          managers: payload.managers.length,
-          teachers: payload.teachers.length,
-          students: payload.students.length,
-          regularLessons: payload.regularLessons.length,
-          groupLessons: payload.groupLessons.length,
-          specialSessions: payload.specialSessions.length,
-          autoAssignRules: payload.autoAssignRules.length,
-          pairConstraints: payload.pairConstraints.length,
-        },
-        data: payload,
-      }
-    }),
   }
 }
 
@@ -4103,14 +4059,6 @@ function AuthenticatedApp() {
     setPersistenceMessage('開発者バックアップを書き出しました。')
   }, [buildWorkspaceSnapshot])
 
-  const exportAnalysisData = useCallback(() => {
-    const snapshot = buildWorkspaceSnapshot(new Date().toISOString())
-    const analysisPayload = buildWorkspaceAnalysisExport(snapshot)
-    downloadTextFile(formatBackupFileName(snapshot.savedAt, 'AI分析用データ'), serializeAnalysisExport(analysisPayload), 'application/json')
-    setLastSavedAt(snapshot.savedAt)
-    setPersistenceMessage('AI分析用データを書き出しました。')
-  }, [buildWorkspaceSnapshot])
-
   const importWorkspaceBackup = useCallback(async (file: File, _password: string) => {
     try {
       const text = await file.text()
@@ -4629,7 +4577,7 @@ function AuthenticatedApp() {
               </div>
             </form>
             <div className="workspace-auth-actions">
-              <button data-testid="firebase-password-reset" className="menu-link-button" type="button" onClick={() => void submitPasswordReset()}>パスワードを忘れた方はこちら</button>
+              <button data-testid="firebase-password-reset" className="menu-link-button" type="button" onClick={() => void submitPasswordReset()}>パスワードリセットまたはパスワード変更</button>
             </div>
             {remoteAuthMessage ? <div data-testid="firebase-auth-message" className="workspace-auth-note workspace-auth-note-error">{remoteAuthMessage}</div> : null}
           </div>
@@ -4745,7 +4693,6 @@ function AuthenticatedApp() {
         onUpdateClassroom={updateClassroom}
         onReplaceClassroomManagerUid={replaceClassroomManagerUid}
         onExportWorkspaceBackup={exportWorkspaceBackup}
-        onExportAnalysisData={exportAnalysisData}
         onImportWorkspaceBackup={importWorkspaceBackup}
         onRestoreAutoBackup={() => {}}
         onLoadStudentHistory={loadStudentHistory}

--- a/src/components/developer-admin/DeveloperAdminScreen.tsx
+++ b/src/components/developer-admin/DeveloperAdminScreen.tsx
@@ -64,7 +64,6 @@ type DeveloperAdminScreenProps = {
   }) => void
   onReplaceClassroomManagerUid: (classroomId: string, managerUserId: string, managerEmail: string) => void
   onExportWorkspaceBackup: () => void
-  onExportAnalysisData: () => void
   onImportWorkspaceBackup: (file: File, password: string) => void
   onRestoreAutoBackup: (backupDateKey: string, password: string) => void
   onLoadStudentHistory: (classroomId: string) => void
@@ -156,7 +155,7 @@ function buildFirebaseConsoleUrl(projectId: string, path: string) {
   return `https://console.firebase.google.com/project/${encodeURIComponent(normalizedProjectId)}${path}`
 }
 
-export function DeveloperAdminScreen({ currentUser, authMode, accountProvisioningLocked, managerEmailLocked, firebaseProjectId, persistenceMessage, developerCloudBackupEnabled, developerCloudBackupFolderName, developerCloudBackupStatus, onConnectDeveloperCloudBackupFolder, onDisconnectDeveloperCloudBackupFolder, classrooms, users, actingClassroomId, onAddClassroom, blazeFreeTierEstimate, serverAutoBackupSummaries, serverAutoBackupLoading, serverAutoBackupDiagnostics, onLoadServerAutoBackupSummaries, onTriggerServerAutoBackup, onRestoreServerAutoBackup, bulkTemporarySuspensionReason, onBulkTemporarySuspensionReasonChange, areAllContractedClassroomsTemporarilySuspended, onToggleContractedClassroomsTemporarySuspension, onUpdateClassroom, onReplaceClassroomManagerUid, onExportWorkspaceBackup, onExportAnalysisData, onImportWorkspaceBackup, onLoadStudentHistory, studentHistoryState, onCloseStudentHistory, restoreModalState, onToggleRestoreClassroom, onSelectAllRestoreClassrooms, onClearAllRestoreClassrooms, onConfirmRestoreSelection, onCancelRestoreSelection, onDeleteClassroom, onOpenClassroom, onLogout }: DeveloperAdminScreenProps) {
+export function DeveloperAdminScreen({ currentUser, authMode, accountProvisioningLocked, managerEmailLocked, firebaseProjectId, persistenceMessage, developerCloudBackupEnabled, developerCloudBackupFolderName, developerCloudBackupStatus, onConnectDeveloperCloudBackupFolder, onDisconnectDeveloperCloudBackupFolder, classrooms, users, actingClassroomId, onAddClassroom, blazeFreeTierEstimate, serverAutoBackupSummaries, serverAutoBackupLoading, serverAutoBackupDiagnostics, onLoadServerAutoBackupSummaries, onTriggerServerAutoBackup, onRestoreServerAutoBackup, bulkTemporarySuspensionReason, onBulkTemporarySuspensionReasonChange, areAllContractedClassroomsTemporarilySuspended, onToggleContractedClassroomsTemporarySuspension, onUpdateClassroom, onReplaceClassroomManagerUid, onExportWorkspaceBackup, onImportWorkspaceBackup, onLoadStudentHistory, studentHistoryState, onCloseStudentHistory, restoreModalState, onToggleRestoreClassroom, onSelectAllRestoreClassrooms, onClearAllRestoreClassrooms, onConfirmRestoreSelection, onCancelRestoreSelection, onDeleteClassroom, onOpenClassroom, onLogout }: DeveloperAdminScreenProps) {
   const workspaceBackupImportRef = useRef<HTMLInputElement | null>(null)
   const [showProvisioningGuide, setShowProvisioningGuide] = useState(false)
   const [serverBackupListExpanded, setServerBackupListExpanded] = useState(false)
@@ -292,7 +291,6 @@ export function DeveloperAdminScreen({ currentUser, authMode, accountProvisionin
             <div className="developer-backup-grid">
               <div className="basic-data-row-actions">
                 <button className="secondary-button slim" type="button" onClick={onExportWorkspaceBackup} data-testid="developer-export-workspace-backup-button">バックアップを書き出す</button>
-                <button className="secondary-button slim" type="button" onClick={onExportAnalysisData}>AI分析用データを書き出す</button>
                 <button className="secondary-button slim" type="button" onClick={() => workspaceBackupImportRef.current?.click()} data-testid="developer-import-workspace-backup-button">バックアップを読み込む</button>
               </div>
             </div>


### PR DESCRIPTION
## 概要
全体見直し Phase 1 / ①（教室権限・ログイン）のうち、独立して安全に外せる部分。

## 変更
- **①**: 開発者画面の「AI分析用データを書き出す」を削除（exportAnalysisData / buildWorkspaceAnalysisExport / serializeAnalysisExport / prop / ボタン）。
- **①**: ログインのパスワードリンク文言を「パスワードリセットまたはパスワード変更」に（動作は同じ）。
- chore: `.claude/` を gitignore に追加。

## 検証
- `npm run build` 通過 / `npm run test:unit` 262件全通過

## 補足（次の段階）
- ①の本丸「Spark手動管理ブランチの撤去（`isRemoteAdminAutomationEnabled` 分岐15箇所・`accountProvisioningLocked`/`managerEmailLocked`/`sparkManualAdminMode`）」と「Google Drive/ブラウザ同期フォルダUI（developerCloudBackup）削除」は影響範囲が広いため別PRで実施予定。**本番は既に Functions 有効（非Spark）のため本番挙動は不変・低リスク**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)