### PR TITLE
Phase 1 / ①: Spark手動管理モードを撤廃（Blaze一本化）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2303,10 +2303,6 @@ function AuthenticatedApp() {
     if (!targetClassroom) return
     const currentManager = workspaceUsers.find((user) => user.id === targetClassroom.managerUserId)
     if (!currentManager) return
-    if (isRemoteBackendEnabled && !isRemoteAdminAutomationEnabled && typeof updates.managerEmail === 'string' && updates.managerEmail !== currentManager.email) {
-      setPersistenceMessage('Spark 構成では管理者メールをアプリから変更できません。Firebase Auth と Firestore members を Console 側で更新してください。')
-      return
-    }
 
     const nextClassroom: WorkspaceClassroom = {
       ...targetClassroom,
@@ -4649,8 +4645,6 @@ function AuthenticatedApp() {
       <DeveloperAdminScreen
         currentUser={currentUser}
         authMode={isRemoteBackendEnabled ? 'firebase' : 'local'}
-        accountProvisioningLocked={isRemoteBackendEnabled && !isRemoteAdminAutomationEnabled}
-        managerEmailLocked={isRemoteBackendEnabled && !isRemoteAdminAutomationEnabled}
         firebaseProjectId={firebaseBackendConfig.projectId}
         persistenceMessage={persistenceMessage}
         developerCloudBackupEnabled={developerCloudBackupEnabled}

--- a/src/components/developer-admin/DeveloperAdminScreen.tsx
+++ b/src/components/developer-admin/DeveloperAdminScreen.tsx
@@ -6,8 +6,6 @@ import type { AppSnapshotPayload, WorkspaceClassroom, WorkspaceUser } from '../.
 type DeveloperAdminScreenProps = {
   currentUser: WorkspaceUser
   authMode: 'local' | 'firebase'
-  accountProvisioningLocked: boolean
-  managerEmailLocked: boolean
   firebaseProjectId: string
   persistenceMessage: string
   developerCloudBackupEnabled: boolean
@@ -155,7 +153,7 @@ function buildFirebaseConsoleUrl(projectId: string, path: string) {
   return `https://console.firebase.google.com/project/${encodeURIComponent(normalizedProjectId)}${path}`
 }
 
-export function DeveloperAdminScreen({ currentUser, authMode, accountProvisioningLocked, managerEmailLocked, firebaseProjectId, persistenceMessage, developerCloudBackupEnabled, developerCloudBackupFolderName, developerCloudBackupStatus, onConnectDeveloperCloudBackupFolder, onDisconnectDeveloperCloudBackupFolder, classrooms, users, actingClassroomId, onAddClassroom, blazeFreeTierEstimate, serverAutoBackupSummaries, serverAutoBackupLoading, serverAutoBackupDiagnostics, onLoadServerAutoBackupSummaries, onTriggerServerAutoBackup, onRestoreServerAutoBackup, bulkTemporarySuspensionReason, onBulkTemporarySuspensionReasonChange, areAllContractedClassroomsTemporarilySuspended, onToggleContractedClassroomsTemporarySuspension, onUpdateClassroom, onReplaceClassroomManagerUid, onExportWorkspaceBackup, onImportWorkspaceBackup, onLoadStudentHistory, studentHistoryState, onCloseStudentHistory, restoreModalState, onToggleRestoreClassroom, onSelectAllRestoreClassrooms, onClearAllRestoreClassrooms, onConfirmRestoreSelection, onCancelRestoreSelection, onDeleteClassroom, onOpenClassroom, onLogout }: DeveloperAdminScreenProps) {
+export function DeveloperAdminScreen({ currentUser, authMode, firebaseProjectId, persistenceMessage, developerCloudBackupEnabled, developerCloudBackupFolderName, developerCloudBackupStatus, onConnectDeveloperCloudBackupFolder, onDisconnectDeveloperCloudBackupFolder, classrooms, users, actingClassroomId, onAddClassroom, blazeFreeTierEstimate, serverAutoBackupSummaries, serverAutoBackupLoading, serverAutoBackupDiagnostics, onLoadServerAutoBackupSummaries, onTriggerServerAutoBackup, onRestoreServerAutoBackup, bulkTemporarySuspensionReason, onBulkTemporarySuspensionReasonChange, areAllContractedClassroomsTemporarilySuspended, onToggleContractedClassroomsTemporarySuspension, onUpdateClassroom, onReplaceClassroomManagerUid, onExportWorkspaceBackup, onImportWorkspaceBackup, onLoadStudentHistory, studentHistoryState, onCloseStudentHistory, restoreModalState, onToggleRestoreClassroom, onSelectAllRestoreClassrooms, onClearAllRestoreClassrooms, onConfirmRestoreSelection, onCancelRestoreSelection, onDeleteClassroom, onOpenClassroom, onLogout }: DeveloperAdminScreenProps) {
   const workspaceBackupImportRef = useRef<HTMLInputElement | null>(null)
   const [showProvisioningGuide, setShowProvisioningGuide] = useState(false)
   const [serverBackupListExpanded, setServerBackupListExpanded] = useState(false)
@@ -170,10 +168,7 @@ export function DeveloperAdminScreen({ currentUser, authMode, accountProvisionin
     contractEndDate: '',
   }))
   const managerById = useMemo(() => new Map(users.filter((user) => user.role === 'manager').map((user) => [user.id, user])), [users])
-  const sparkManualAdminMode = authMode === 'firebase' && accountProvisioningLocked
-  const firebaseSummary = accountProvisioningLocked || managerEmailLocked
-    ? 'Firebase Hosting / Auth / Firestore で運用します。教室追加はこの画面から実行でき、既存教室の管理者 UID 差し替えもここで行えます。旧 Authentication ユーザー削除と管理者メール変更は Firebase Console で手動確認が必要です。'
-    : 'Firebase Hosting / Auth / Firestore / Functions で運用します。教室追加と削除は Functions が処理し、管理者 UID 差し替え時は旧 Authentication ユーザーも自動削除します。教室追加で UID を指定した場合は、その既存 Auth アカウントと既存パスワードをそのまま使います。'
+  const firebaseSummary = 'Firebase Hosting / Auth / Firestore / Functions で運用します。教室追加と削除は Functions が処理し、管理者 UID 差し替え時は旧 Authentication ユーザーも自動削除します。教室追加で UID を指定した場合は、その既存 Auth アカウントと既存パスワードをそのまま使います。'
   const firebaseAuthUrl = buildFirebaseConsoleUrl(firebaseProjectId, '/authentication/users')
   const todayDateKey = useMemo(() => new Date().toISOString().slice(0, 10), [])
   const todayLabel = useMemo(() => {
@@ -268,7 +263,6 @@ export function DeveloperAdminScreen({ currentUser, authMode, accountProvisionin
               <button className="primary-button" type="button" onClick={handleAddClassroom}>教室を追加</button>
             </div>
           </div>
-          {sparkManualAdminMode ? <div className="toolbar-status">教室削除と管理者メール変更は Firebase Console で実施してください。</div> : null}
 
           <div className="basic-data-row-actions" style={{ marginBottom: 12 }}>
             <a className="secondary-button slim developer-guide-link-button" href="/billing">生徒数・請求一覧を表示</a>
@@ -404,7 +398,7 @@ export function DeveloperAdminScreen({ currentUser, authMode, accountProvisionin
                     </label>
                     <label className="basic-data-inline-field">
                       <span>管理者メール</span>
-                      <input type="email" value={manager?.email ?? ''} onChange={(event) => onUpdateClassroom(classroom.id, { managerEmail: event.target.value })} disabled={managerEmailLocked} />
+                      <input type="email" value={manager?.email ?? ''} onChange={(event) => onUpdateClassroom(classroom.id, { managerEmail: event.target.value })} />
                     </label>
                   </div>
 

--- a/src/integrations/firebase/config.ts
+++ b/src/integrations/firebase/config.ts
@@ -53,6 +53,7 @@ export function isFirebaseBackendEnabled() {
 }
 
 export function isFirebaseAdminFunctionsEnabled() {
-  const config = getFirebaseBackendConfig()
-  return config.enabled && config.adminFunctionsEnabled
+  // Spark廃止: Firebase運用は常に Functions 有効(Blaze)前提とし、教室追加/削除・管理者発行/メール変更は
+  // すべてアプリ内(Functions)で完結する。adminFunctionsEnabled フラグによる手動運用分岐は撤廃。
+  return getFirebaseBackendConfig().enabled
 }


### PR DESCRIPTION
## 概要
①教室権限のうち「Spark手動管理モード」を撤廃。

## 設計（低リスク）
本番は元々 `VITE_FIREBASE_ENABLE_FUNCTIONS=true`（非Spark）で稼働しているため、`isFirebaseAdminFunctionsEnabled` を「Firebase有効時は常にtrue」に変更するだけで Spark は到達不能になり、`isRemoteAdminAutomationEnabled` を参照する15箇所は無改修で正しく動作する。あとは常にfalseになる Spark専用の枝のみ除去。

## 変更
- `config.ts`: `isFirebaseAdminFunctionsEnabled` を Functions常時有効前提に。
- Spark専用の `accountProvisioningLocked` / `managerEmailLocked` / `sparkManualAdminMode` と、管理者メールConsole手動の枝・Console手動の案内UIを撤去。
- 教室追加/削除・管理者発行/メール変更はアプリ内(Functions)で完結。

## 検証
- `npm run build` 通過 / `npm run test:unit` 262件全通過 / 残存参照なし
- **本番は元々Functions有効のため挙動は不変**。

## 残（①の最後）
- Google Drive/ブラウザ同期フォルダUI（`developerCloudBackup`）削除は App.tsx だけで95箇所と深く、本番保存データにもフィールドがあるため、別途スコープ判断のうえ対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)