### PR TITLE
Phase 2: 保存UX（5s/20s・ボタン常時緑・オフラインブロック）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3828,12 +3828,13 @@ function AuthenticatedApp() {
     if (dataSignature === cleanSignatureRef.current) return
 
     // 自動保存は1編集ごとに workspace 全体を IndexedDB へ直列化(structuredClone)するため、
-    // 出席を連続入力する巨大教室では編集ピークの一因になっていた。debounce を 2 秒に延ばして
+    // 出席を連続入力する巨大教室では編集ピークの一因になっていた。debounce を 5 秒に延ばして
     // 連続入力中の保存をまとめる。ただし保存されない時間が延びすぎないよう、前回保存から
-    // 最大 15 秒(maxWait)で必ず保存する。タブ切替/最小化/クローズ時は別途 visibilitychange/
+    // 最大 20 秒(maxWait)で必ず保存する。タブ切替/最小化/クローズ時は別途 visibilitychange/
     // beforeunload で flush されるため、通常の離脱でデータは失われない(クラッシュ時の未保存幅のみ拡大)。
-    const AUTOSAVE_DEBOUNCE_MS = 2000
-    const AUTOSAVE_MAX_WAIT_MS = 15000
+    // (spec-save-restore.md §1: デバウンス5秒 / 最大20秒)
+    const AUTOSAVE_DEBOUNCE_MS = 5000
+    const AUTOSAVE_MAX_WAIT_MS = 20000
     const elapsedSinceLastSave = Date.now() - autosaveLastStartedAtRef.current
     const autosaveDelay = Math.max(0, Math.min(AUTOSAVE_DEBOUNCE_MS, AUTOSAVE_MAX_WAIT_MS - elapsedSinceLastSave))
 

--- a/src/components/OfflineGate.tsx
+++ b/src/components/OfflineGate.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { isFirebaseBackendEnabled } from '../integrations/firebase/config'
+
+// オフライン時のブロック(spec-save-restore.md §3)。
+// このアプリはクラウド(Firebase)前提のため、オフラインでは盤面を表示せず操作を遮断する。
+// アプリ本体はアンマウントせず、全画面オーバーレイで操作だけを遮断する(状態を保持し、
+// 接続回復で自動的に解除)。ローカル開発(Firebase無効)では遮断しない。
+export function OfflineGate() {
+  const [isOffline, setIsOffline] = useState(() => typeof navigator !== 'undefined' && navigator.onLine === false)
+
+  useEffect(() => {
+    const update = () => setIsOffline(!navigator.onLine)
+    window.addEventListener('online', update)
+    window.addEventListener('offline', update)
+    update()
+    return () => {
+      window.removeEventListener('online', update)
+      window.removeEventListener('offline', update)
+    }
+  }, [])
+
+  if (!isOffline || !isFirebaseBackendEnabled()) return null
+
+  return (
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="オフラインのため使用できません"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 99999,
+        background: 'rgba(20,24,33,0.94)',
+        color: '#fff',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: 24,
+        fontFamily: "'BIZ UDPGothic', 'Yu Gothic', 'Meiryo', sans-serif",
+      }}
+    >
+      <div style={{ fontSize: 48, marginBottom: 12 }} aria-hidden="true">⚠</div>
+      <h2 style={{ fontSize: 20, margin: '0 0 8px', fontWeight: 700 }}>オフラインのため使用できません</h2>
+      <p style={{ fontSize: 14, lineHeight: 1.7, maxWidth: 380, margin: 0 }}>
+        このアプリはインターネット接続が必要です。<br />
+        接続状況をご確認ください。<br />
+        接続が回復すると自動的に操作できるようになります。
+      </p>
+    </div>
+  )
+}

--- a/src/components/schedule-board/BoardToolbar.tsx
+++ b/src/components/schedule-board/BoardToolbar.tsx
@@ -119,9 +119,11 @@ function BoardToolbarComponent({
     setSavePressed(false)
   }
   const isSavingInProgress = savePressed || Boolean(isBoardSaving) || Boolean(isBoardSaveDisabled)
-  // 保存待ちのデータがある限り押せるようにする（「保存」表示なのに押せない状態を防ぐ）。
-  const isSaveButtonDisabled = isSavingInProgress || !hasPendingSave
+  // 常時クリック可能(グレーアウトしない／常に緑)。保存中だけ無効化して二重実行を防ぐ。
+  // 未保存が無いとき(=「最新データ」表示)は押しても no-op。spec-save-restore.md §1。
+  const isSaveButtonDisabled = isSavingInProgress
   const handleSaveBoardClick = () => {
+    if (!hasPendingSave) return
     setSavePressed(true)
     // スピナーの描画を先に確定させてから保存処理を走らせる（同期的な重い処理で
     // 「保存中…」表示が遅れる/飛ぶのを防ぐ）。
@@ -249,7 +251,7 @@ function BoardToolbarComponent({
                 <button className="segment-button" type="button" onClick={onGoNextWeek} disabled={!canGoNextWeek} data-testid="next-week-button">次週 ▶</button>
               </div>
               <button
-                className={`primary-button slim${hasPendingSave || isSavingInProgress ? '' : ' is-clean'}`}
+                className="primary-button slim"
                 type="button"
                 onClick={handleSaveBoardClick}
                 disabled={isSaveButtonDisabled}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import packageJson from '../package.json'
 import { startMemoryDiagnostics } from './utils/memoryDiagnostics'
+import { OfflineGate } from './components/OfflineGate'
 
 // ?memlog=1 のときだけメモリ診断ログを開始する（通常は何もしない）。
 startMemoryDiagnostics()
@@ -75,6 +76,7 @@ if (submissionToken) {
     createRoot(document.getElementById('root')!).render(
       <StrictMode>
         <App />
+        <OfflineGate />
         <div className="app-version-badge">v{packageJson.version}</div>
       </StrictMode>,
     )


### PR DESCRIPTION
## 概要
Phase 2（表示・データの簡素化）のうち ② 保存UX 一式。

## 変更
- **自動保存デバウンス 2s/15s → 5s/20s**（spec-save-restore.md §1）
- **保存ボタンを常時緑・常時クリック可**に（グレーアウト廃止。保存中のみ無効化、未保存無し時は押下no-op）
- **オフライン時の操作ブロック**：Firebase運用時 `navigator.onLine=false` で全画面オーバーレイ。接続回復で自動解除。提出/共有ページは対象外。ローカル開発では無効（spec-save-restore.md §3）

## 検証
- `npm run build` 通過 / `npm run test:unit` 262件全通過

## Phase 2 残り
- 色分け撤廃（③⑨）／ ⑥isHidden廃止・在籍判定（日付＋高3卒業）・講師項目削減 … 次PRで。

🤖 Generated with [Claude Code](https://claude.com/claude-code)