### PR TITLE
Phase 2 / ⑥: 講師の出勤可能コマ・メモを廃止

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -169,7 +169,6 @@ describe('buildSubmissionAcknowledgementEntries', () => {
         entryDate: '2026-04-01',
         withdrawDate: '未定',
         subjectCapabilities: [],
-        memo: '',
       }],
     })
 

--- a/src/components/basic-data/BasicDataScreen.test.ts
+++ b/src/components/basic-data/BasicDataScreen.test.ts
@@ -3,24 +3,6 @@ import * as xlsx from 'xlsx'
 import { createTemplateBundle, mergeImportedBundle, parseImportedBundle } from './BasicDataScreen'
 
 describe('BasicDataScreen parseImportedBundle', () => {
-  it('parses imported teacher available slots', () => {
-    const workbook = xlsx.utils.book_new()
-
-    xlsx.utils.book_append_sheet(workbook, xlsx.utils.json_to_sheet([
-      { 名前: '田中講師', 表示名: '田中講師', メール: '', 入塾日: '2024-04-01', 退塾日: '', 表示: '表示', 担当科目: '数:高3', 出勤可能コマ: '月4限, 木2限, 日5限', メモ: '' },
-    ]), '講師')
-
-    const parsed = parseImportedBundle(xlsx, workbook, createTemplateBundle())
-
-    expect(parsed.teachers[0]).toMatchObject({
-      availableSlots: [
-        { dayOfWeek: 1, slotNumber: 4 },
-        { dayOfWeek: 4, slotNumber: 2 },
-        { dayOfWeek: 0, slotNumber: 5 },
-      ],
-    })
-  })
-
   it('assigns sequential ids to imported rows without id columns', () => {
     const workbook = xlsx.utils.book_new()
 
@@ -83,7 +65,6 @@ describe('BasicDataScreen parseImportedBundle', () => {
     expect(merged.teachers.find((row) => row.id === targetTeacher?.id)).toEqual(expect.objectContaining({
       displayName: '田中先生',
       email: 'tanaka-updated@example.com',
-      memo: '差分更新',
     }))
     expect(merged.teachers.find((row) => row.id === untouchedTeacher?.id)).toEqual(untouchedTeacher)
     expect(merged.students.find((row) => row.id === targetStudent?.id)).toEqual(expect.objectContaining({
@@ -130,7 +111,6 @@ describe('BasicDataScreen parseImportedBundle', () => {
 
     expect(merged.teachers.find((row) => row.id === targetTeacher?.id)).toEqual(expect.objectContaining({
       email: 'tanaka-name-match@example.com',
-      memo: '名前照合',
     }))
     expect(merged.students.find((row) => row.id === targetStudent?.id)).toEqual(expect.objectContaining({
       email: 'aoki-name-match@example.com',

--- a/src/components/basic-data/BasicDataScreen.tsx
+++ b/src/components/basic-data/BasicDataScreen.tsx
@@ -1,20 +1,13 @@
 import { type Dispatch, type SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import type { ClassroomSettings } from '../../types/appState'
 import {
-  buildTeacherAvailableSlotLabel,
   compareStudentsByCurrentGradeThenName,
   deriveManagedDisplayName,
   type GradeCeiling,
   type ManagerRow,
-  normalizeTeacherAvailableSlots,
-  parseTeacherAvailableSlots,
   resolveManagementRosterStatusLabel,
   resolveCurrentStudentGradeLabel,
-  serializeTeacherAvailableSlots,
   type StudentRow,
-  teacherAvailabilityDayOptions,
-  teacherAvailabilitySlotNumbers,
-  type TeacherAvailableSlot,
   type TeacherRow,
   type TeacherSubjectCapability,
   formatManagedDateValue,
@@ -380,9 +373,6 @@ function formatSummaryValue(value: string, fallback = '未設定') {
   return normalizeText(value) || fallback
 }
 
-function formatTeacherAvailabilitySummary(slots: TeacherAvailableSlot[] | undefined) {
-  return serializeTeacherAvailableSlots(slots) || '未設定'
-}
 
 function formatManagedDateButtonLabel(value: string, emptyLabel: string, hint?: string) {
   const normalizedValue = normalizeText(value)
@@ -478,8 +468,6 @@ export function buildWorkbook(xlsx: XlsxModule, bundle: BasicDataBundle) {
     入塾日: row.entryDate,
     退塾日: normalizeDateString(row.withdrawDate),
     担当科目: serializeSubjectCapabilities(row.subjectCapabilities),
-    出勤可能コマ: serializeTeacherAvailableSlots(row.availableSlots),
-    メモ: row.memo,
   })), ['入塾日', '退塾日']), '講師')
 
   xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, bundle.students.map((row) => ({
@@ -521,7 +509,6 @@ export function buildWorkbook(xlsx: XlsxModule, bundle: BasicDataBundle) {
   xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, [
     { 項目: '各ID列', 説明: '現データ出力に含まれる ID 列は差分取り込みの照合に使います。差分更新時は削除せずそのまま残してください。新規行は空欄でも取り込めます。' },
     { 項目: '講師.担当科目', 説明: '英:高3, 数:中 のように 科目:上限学年 をカンマ区切りで記入します。' },
-    { 項目: '講師.出勤可能コマ', 説明: '月1限, 木3限 のように曜日と時限をカンマ区切りで記入します。通常授業がなくてもコマ表へ講師だけ表示します。' },
     { 項目: '講師/生徒.入塾日', 説明: 'YYYY-MM-DD 形式に加えて Excel の日付セルも取り込めます。空欄なら即時在籍として扱います。' },
     { 項目: '講師/生徒.退塾日', 説明: 'YYYY-MM-DD または Excel の日付セルで入力できます。空欄と 未定 はどちらも日付未設定として扱います。' },
     { 項目: '生徒.生年月日', 説明: 'YYYY-MM-DD 形式または Excel の日付セルで入力できます。学年/在籍列はアプリ側で自動計算します。' },
@@ -595,8 +582,6 @@ export function parseImportedBundle(xlsx: XlsxModule, workbook: import('xlsx').W
           entryDate: normalizeDateString(row['入塾日'], xlsx),
           withdrawDate: normalizeDateString(row['退塾日'], xlsx) || normalizeText(row['退塾日']) || '未定',
           subjectCapabilities: parseSubjectCapabilities(row['担当科目']),
-          availableSlots: parseTeacherAvailableSlots(row['出勤可能コマ']),
-          memo: normalizeText(row['メモ']),
         }))
         .filter((row) => row.name)
     : fallback.teachers
@@ -792,74 +777,8 @@ function SubjectCapabilityEditor({ capabilities, onChange, testIdPrefix, disable
   )
 }
 
-type TeacherAvailabilityEditorProps = {
-  slots: TeacherAvailableSlot[]
-  onChange: (next: TeacherAvailableSlot[]) => void
-  testIdPrefix?: string
-  disabled?: boolean
-}
-
-function TeacherAvailabilityEditor({ slots, onChange, testIdPrefix, disabled = false }: TeacherAvailabilityEditorProps) {
-  const normalizedSlots = normalizeTeacherAvailableSlots(slots)
-
-  const toggleSlot = (dayOfWeek: number, slotNumber: number) => {
-    const exists = normalizedSlots.some((slot) => slot.dayOfWeek === dayOfWeek && slot.slotNumber === slotNumber)
-    if (exists) {
-      onChange(normalizedSlots.filter((slot) => !(slot.dayOfWeek === dayOfWeek && slot.slotNumber === slotNumber)))
-      return
-    }
-
-    onChange(normalizeTeacherAvailableSlots([...normalizedSlots, { dayOfWeek, slotNumber }]))
-  }
-
-  return (
-    <div className="basic-data-inline-stack">
-      <div className="basic-data-capability-list" data-testid={testIdPrefix ? `${testIdPrefix}-available-slots` : undefined}>
-        {normalizedSlots.length === 0 ? <span className="basic-data-muted-inline">未設定</span> : normalizedSlots.map((slot) => (
-          <span key={`${slot.dayOfWeek}_${slot.slotNumber}`} className="status-chip secondary basic-data-capability-item">
-            {buildTeacherAvailableSlotLabel(slot)}
-            <button
-              className="basic-data-capability-remove"
-              type="button"
-              onClick={() => toggleSlot(slot.dayOfWeek, slot.slotNumber)}
-              disabled={disabled}
-            >
-              ×
-            </button>
-          </span>
-        ))}
-      </div>
-      <div className="basic-data-availability-grid">
-        {teacherAvailabilityDayOptions.map((day) => (
-          <div key={day.value} className="basic-data-availability-row">
-            <span className="basic-data-availability-day">{day.label}</span>
-            <div className="basic-data-chip-row">
-              {teacherAvailabilitySlotNumbers.map((slotNumber) => {
-                const isActive = normalizedSlots.some((slot) => slot.dayOfWeek === day.value && slot.slotNumber === slotNumber)
-                return (
-                  <button
-                    key={`${day.value}_${slotNumber}`}
-                    type="button"
-                    className={`basic-data-chip${isActive ? ' active' : ''}`}
-                    onClick={() => toggleSlot(day.value, slotNumber)}
-                    disabled={disabled}
-                    data-testid={testIdPrefix ? `${testIdPrefix}-available-slot-${day.value}-${slotNumber}` : undefined}
-                  >
-                    {slotNumber}限
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        ))}
-      </div>
-      <p className="basic-data-subcopy">選んだ曜日と時限は、通常授業がなくても講師だけコマ表へ表示します。</p>
-    </div>
-  )
-}
-
 type TeacherEditorModalState = {
-  editor: 'capabilities' | 'availability'
+  editor: 'capabilities'
   target: 'draft' | 'row'
   rowId?: string
 }
@@ -952,7 +871,7 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
   const [statusMessage, setStatusMessage] = useState('')
 
 
-  const [teacherDraft, setTeacherDraft] = useState({ name: '', displayName: '', email: '', entryDate: '', withdrawDate: '', memo: '', subjectCapabilities: [] as TeacherSubjectCapability[], availableSlots: [] as TeacherAvailableSlot[] })
+  const [teacherDraft, setTeacherDraft] = useState({ name: '', displayName: '', email: '', entryDate: '', withdrawDate: '', subjectCapabilities: [] as TeacherSubjectCapability[] })
   const [teacherEditorModalState, setTeacherEditorModalState] = useState<TeacherEditorModalState | null>(null)
   const [studentDraft, setStudentDraft] = useState({ name: '', displayName: '', email: '', entryDate: '', withdrawDate: '', birthDate: '' })
   const [editingRows, setEditingRows] = useState<Record<string, boolean>>({})
@@ -1074,58 +993,34 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
     if (!teacherEditorModalState) return null
 
     if (teacherEditorModalState.target === 'draft') {
-      return teacherEditorModalState.editor === 'capabilities'
-        ? {
-            title: '講師の担当科目',
-            summaryLabel: '科目',
-            editor: (
-              <SubjectCapabilityEditor
-                capabilities={teacherDraft.subjectCapabilities}
-                onChange={(next) => setTeacherDraft((current) => ({ ...current, subjectCapabilities: next }))}
-                testIdPrefix="basic-data-teacher-draft"
-              />
-            ),
-          }
-        : {
-            title: '講師の出勤可能コマ',
-            summaryLabel: '出勤可',
-            editor: (
-              <TeacherAvailabilityEditor
-                slots={teacherDraft.availableSlots}
-                onChange={(next) => setTeacherDraft((current) => ({ ...current, availableSlots: normalizeTeacherAvailableSlots(next) }))}
-                testIdPrefix="basic-data-teacher-draft"
-              />
-            ),
-          }
+      return {
+        title: '講師の担当科目',
+        summaryLabel: '科目',
+        editor: (
+          <SubjectCapabilityEditor
+            capabilities={teacherDraft.subjectCapabilities}
+            onChange={(next) => setTeacherDraft((current) => ({ ...current, subjectCapabilities: next }))}
+            testIdPrefix="basic-data-teacher-draft"
+          />
+        ),
+      }
     }
 
     const baseTeacher = teachers.find((row) => row.id === teacherEditorModalState.rowId)
     if (!baseTeacher) return null
     const targetTeacher = { ...baseTeacher, ...teacherDrafts[baseTeacher.id] }
 
-    return teacherEditorModalState.editor === 'capabilities'
-      ? {
-          title: `${getTeacherDisplayName(targetTeacher)} の担当科目`,
-          summaryLabel: '科目',
-          editor: (
-            <SubjectCapabilityEditor
-              capabilities={targetTeacher.subjectCapabilities}
-              onChange={(next) => updateTeacher(targetTeacher.id, { subjectCapabilities: next })}
-              testIdPrefix={`basic-data-teacher-${targetTeacher.id}`}
-            />
-          ),
-        }
-      : {
-          title: `${getTeacherDisplayName(targetTeacher)} の出勤可能コマ`,
-          summaryLabel: '出勤可',
-          editor: (
-            <TeacherAvailabilityEditor
-              slots={targetTeacher.availableSlots ?? []}
-              onChange={(next) => updateTeacher(targetTeacher.id, { availableSlots: normalizeTeacherAvailableSlots(next) })}
-              testIdPrefix={`basic-data-teacher-${targetTeacher.id}`}
-            />
-          ),
-        }
+    return {
+      title: `${getTeacherDisplayName(targetTeacher)} の担当科目`,
+      summaryLabel: '科目',
+      editor: (
+        <SubjectCapabilityEditor
+          capabilities={targetTeacher.subjectCapabilities}
+          onChange={(next) => updateTeacher(targetTeacher.id, { subjectCapabilities: next })}
+          testIdPrefix={`basic-data-teacher-${targetTeacher.id}`}
+        />
+      ),
+    }
   })()
 
   const addTeacher = () => {
@@ -1140,11 +1035,9 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
         entryDate: teacherDraft.entryDate,
         withdrawDate: teacherDraft.withdrawDate.trim() || '未定',
         subjectCapabilities: teacherDraft.subjectCapabilities,
-        availableSlots: normalizeTeacherAvailableSlots(teacherDraft.availableSlots),
-        memo: teacherDraft.memo.trim(),
       },
     ])
-    setTeacherDraft({ name: '', displayName: '', email: '', entryDate: '', withdrawDate: '未定', memo: '', subjectCapabilities: [], availableSlots: [] })
+    setTeacherDraft({ name: '', displayName: '', email: '', entryDate: '', withdrawDate: '未定', subjectCapabilities: [] })
     setTeacherEditorModalState((current) => current?.target === 'draft' ? null : current)
     setStatusMessage('講師を追加しました。')
   }
@@ -1188,14 +1081,13 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
     const filteredTeachers = filterAndSortRows(
       visibleTeachers,
       tableControls.teachers,
-      (row) => [row.name, getTeacherDisplayName(row), row.email, row.entryDate, row.withdrawDate, resolveTeacherStatusLabel(row), formatSubjectCapabilitySummary(row.subjectCapabilities), formatTeacherAvailabilitySummary(row.availableSlots), row.memo],
+      (row) => [row.name, getTeacherDisplayName(row), row.email, row.entryDate, row.withdrawDate, resolveTeacherStatusLabel(row), formatSubjectCapabilitySummary(row.subjectCapabilities)],
       {
         name: (row) => getTeacherDisplayName(row),
         entryDate: (row) => row.entryDate,
         withdrawDate: (row) => formatManagedDateValue(row.withdrawDate),
         status: (row) => resolveTeacherStatusLabel(row),
         subjects: (row) => formatSubjectCapabilitySummary(row.subjectCapabilities),
-        availability: (row) => formatTeacherAvailabilitySummary(row.availableSlots),
       },
     )
     const orderedTeachers = applyFrozenRowOrder(filteredTeachers, frozenRowOrders.teacher)
@@ -1226,17 +1118,6 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
                 <strong>{formatSubjectCapabilitySummary(teacherDraft.subjectCapabilities)}</strong>
               </button>
             </div>
-            <div className="basic-data-inline-editor-slot basic-data-inline-editor-slot-teacher">
-              <button
-                className="basic-data-inline-summary basic-data-inline-summary-button"
-                type="button"
-                onClick={() => setTeacherEditorModalState({ target: 'draft', editor: 'availability' })}
-                data-testid="basic-data-teacher-draft-availability-summary"
-              >
-                <span className="basic-data-inline-summary-label">出勤可</span>
-                <strong>{formatTeacherAvailabilitySummary(teacherDraft.availableSlots)}</strong>
-              </button>
-            </div>
             <label className="basic-data-inline-field basic-data-inline-field-medium">
               <span>メール</span>
               <input value={teacherDraft.email} onChange={(event) => setTeacherDraft((current) => ({ ...current, email: event.target.value }))} placeholder="メールアドレス" type="email" data-testid="basic-data-teacher-draft-email" />
@@ -1248,10 +1129,6 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
             <label className="basic-data-inline-field basic-data-inline-field-short">
               <span>退塾日</span>
               <DateAssistInput value={teacherDraft.withdrawDate} emptyLabel="退塾日を選択" hint="未定の場合未入力" onChange={(value) => setTeacherDraft((current) => ({ ...current, withdrawDate: value }))} testIdPrefix="basic-data-teacher-draft-withdraw-date" />
-            </label>
-            <label className="basic-data-inline-field basic-data-inline-field-short">
-              <span>メモ</span>
-              <input value={teacherDraft.memo} onChange={(event) => setTeacherDraft((current) => ({ ...current, memo: event.target.value }))} placeholder="メモ" data-testid="basic-data-teacher-draft-memo" />
             </label>
             <button className="primary-button" type="button" onClick={addTeacher} data-testid="basic-data-add-teacher-button">追加</button>
           </div>
@@ -1274,7 +1151,7 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
             </div>
           </div>
           <table className="basic-data-table" data-testid="basic-data-teachers-table">
-            <thead><tr><th>氏名</th><th>表示名</th><th>メール</th><th>入塾日</th><th>退塾日</th><th>状態</th><th>科目</th><th>メモ</th><th>操作</th></tr></thead>
+            <thead><tr><th>氏名</th><th>表示名</th><th>メール</th><th>入塾日</th><th>退塾日</th><th>状態</th><th>科目</th><th>操作</th></tr></thead>
             <tbody>
               {orderedTeachers.map((originalRow) => {
                 const draft = teacherDrafts[originalRow.id]
@@ -1320,11 +1197,6 @@ export function BasicDataScreen({ classroomSettings, teachers, students, onUpdat
                           </button>
                         )
                       : <span className="basic-data-cell-summary" data-testid={`basic-data-teacher-capabilities-${row.id}`}>{formatSubjectCapabilitySummary(row.subjectCapabilities)}</span>}
-                  </td>
-                  <td>
-                    {isRowEditing('teacher', row.id)
-                      ? <input value={row.memo} onChange={(event) => updateTeacher(row.id, { memo: event.target.value })} />
-                      : <span className="basic-data-cell-summary">{formatSummaryValue(row.memo)}</span>}
                   </td>
                   <td>
                     <div className="basic-data-row-actions">

--- a/src/components/basic-data/basicDataModel.test.ts
+++ b/src/components/basic-data/basicDataModel.test.ts
@@ -23,7 +23,6 @@ function createTeacher(overrides: Partial<TeacherRow> = {}): TeacherRow {
     entryDate: '2024-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }],
-    memo: '',
     ...overrides,
   }
 }

--- a/src/components/basic-data/basicDataModel.ts
+++ b/src/components/basic-data/basicDataModel.ts
@@ -3,21 +3,6 @@ import { hasGraduatedHighSchool, resolveEnrollmentYearFromBirthDateParts, resolv
 export type GradeCeiling = '小' | '中' | '高1' | '高2' | '高3'
 export type ManagerRow = { id: string; name: string; email: string }
 export type TeacherSubjectCapability = { subject: string; maxGrade: GradeCeiling }
-export type TeacherAvailableSlot = { dayOfWeek: number; slotNumber: number }
-
-export const teacherAvailabilityDayOptions = [
-  { value: 1, label: '月' },
-  { value: 2, label: '火' },
-  { value: 3, label: '水' },
-  { value: 4, label: '木' },
-  { value: 5, label: '金' },
-  { value: 6, label: '土' },
-  { value: 0, label: '日' },
-] as const
-
-export const teacherAvailabilitySlotNumbers = [1, 2, 3, 4, 5] as const
-
-const teacherAvailabilityDayValueByLabel = new Map<string, number>(teacherAvailabilityDayOptions.map((entry) => [entry.label, entry.value]))
 
 export type TeacherRow = {
   id: string
@@ -27,8 +12,6 @@ export type TeacherRow = {
   entryDate: string
   withdrawDate: string
   subjectCapabilities: TeacherSubjectCapability[]
-  availableSlots?: TeacherAvailableSlot[]
-  memo: string
 }
 export type StudentRow = {
   id: string
@@ -41,70 +24,17 @@ export type StudentRow = {
 }
 
 export const initialTeachers: TeacherRow[] = [
-  { id: 't001', name: '田中講師', email: 'tanaka@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '英', maxGrade: '高2' }], availableSlots: [], memo: '数学メイン' },
-  { id: 't002', name: '佐藤講師', email: 'sato@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '数', maxGrade: '中' }], availableSlots: [], memo: '英語メイン' },
-  { id: 't003', name: '鈴木講師', email: 'suzuki@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '理', maxGrade: '高2' }], availableSlots: [], memo: '理数対応' },
-  { id: 't004', name: '高橋講師', email: 'takahashi@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '国', maxGrade: '高3' }], availableSlots: [], memo: '文系対応' },
-  { id: 't005', name: '伊藤講師', email: 'ito-teacher@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '国', maxGrade: '高3' }, { subject: '社', maxGrade: '高3' }], availableSlots: [], memo: '国社中心' },
-  { id: 't006', name: '渡辺講師', email: 'watanabe@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '理', maxGrade: '高3' }], availableSlots: [], memo: '理科中心' },
-  { id: 't007', name: '中村講師', email: 'nakamura@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '社', maxGrade: '高2' }], availableSlots: [], memo: '英社対応' },
-  { id: 't008', name: '小林講師', email: 'kobayashi@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高2' }, { subject: '英', maxGrade: '高1' }], availableSlots: [], memo: '中学生中心' },
-  { id: 't009', name: '加藤講師', email: 'kato@example.com', entryDate: '2026-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高2' }], availableSlots: [], memo: '4月着任予定' },
-  { id: 't010', name: '吉田講師', email: 'yoshida@example.com', entryDate: '2024-04-01', withdrawDate: '2025-03-31', subjectCapabilities: [{ subject: '国', maxGrade: '高3' }, { subject: '社', maxGrade: '高3' }], availableSlots: [], memo: '休職のため退塾日で非在籍扱い' },
+  { id: 't001', name: '田中講師', email: 'tanaka@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '英', maxGrade: '高2' }] },
+  { id: 't002', name: '佐藤講師', email: 'sato@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '数', maxGrade: '中' }] },
+  { id: 't003', name: '鈴木講師', email: 'suzuki@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '理', maxGrade: '高2' }] },
+  { id: 't004', name: '高橋講師', email: 'takahashi@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '国', maxGrade: '高3' }] },
+  { id: 't005', name: '伊藤講師', email: 'ito-teacher@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '国', maxGrade: '高3' }, { subject: '社', maxGrade: '高3' }] },
+  { id: 't006', name: '渡辺講師', email: 'watanabe@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '理', maxGrade: '高3' }] },
+  { id: 't007', name: '中村講師', email: 'nakamura@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '社', maxGrade: '高2' }] },
+  { id: 't008', name: '小林講師', email: 'kobayashi@example.com', entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高2' }, { subject: '英', maxGrade: '高1' }] },
+  { id: 't009', name: '加藤講師', email: 'kato@example.com', entryDate: '2026-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '英', maxGrade: '高2' }] },
+  { id: 't010', name: '吉田講師', email: 'yoshida@example.com', entryDate: '2024-04-01', withdrawDate: '2025-03-31', subjectCapabilities: [{ subject: '国', maxGrade: '高3' }, { subject: '社', maxGrade: '高3' }] },
 ]
-
-function resolveTeacherAvailabilityDaySortValue(dayOfWeek: number) {
-  return dayOfWeek === 0 ? 7 : dayOfWeek
-}
-
-export function normalizeTeacherAvailableSlots(slots: TeacherAvailableSlot[] | undefined) {
-  const uniqueSlots = new Map<string, TeacherAvailableSlot>()
-
-  for (const slot of slots ?? []) {
-    const dayOfWeek = Number(slot.dayOfWeek)
-    const slotNumber = Number(slot.slotNumber)
-    if (!Number.isInteger(dayOfWeek) || !Number.isInteger(slotNumber)) continue
-    if (!teacherAvailabilityDayOptions.some((entry) => entry.value === dayOfWeek)) continue
-    if (!teacherAvailabilitySlotNumbers.includes(slotNumber as (typeof teacherAvailabilitySlotNumbers)[number])) continue
-    uniqueSlots.set(`${dayOfWeek}_${slotNumber}`, { dayOfWeek, slotNumber })
-  }
-
-  return Array.from(uniqueSlots.values())
-    .sort((left, right) => {
-      const dayDiff = resolveTeacherAvailabilityDaySortValue(left.dayOfWeek) - resolveTeacherAvailabilityDaySortValue(right.dayOfWeek)
-      if (dayDiff !== 0) return dayDiff
-      return left.slotNumber - right.slotNumber
-    })
-}
-
-export function buildTeacherAvailableSlotLabel(slot: TeacherAvailableSlot) {
-  const dayLabel = teacherAvailabilityDayOptions.find((entry) => entry.value === slot.dayOfWeek)?.label ?? '?'
-  return `${dayLabel}${slot.slotNumber}限`
-}
-
-export function serializeTeacherAvailableSlots(slots: TeacherAvailableSlot[] | undefined) {
-  return normalizeTeacherAvailableSlots(slots)
-    .map((slot) => buildTeacherAvailableSlotLabel(slot))
-    .join(', ')
-}
-
-export function parseTeacherAvailableSlots(value: unknown) {
-  const entries = String(value ?? '')
-    .split(/[、,\n\/]+/u)
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-
-  const slots: TeacherAvailableSlot[] = []
-  for (const entry of entries) {
-    const matched = entry.match(/([日月火水木金土])(?:曜)?\s*([1-5])(?:限)?/u)
-    if (!matched) continue
-    const dayOfWeek = teacherAvailabilityDayValueByLabel.get(matched[1] ?? '')
-    if (dayOfWeek === undefined) continue
-    slots.push({ dayOfWeek, slotNumber: Number(matched[2]) })
-  }
-
-  return normalizeTeacherAvailableSlots(slots)
-}
 
 export const initialStudents: StudentRow[] = [
   { id: 's001', name: '青木 太郎', displayName: '青木太郎', email: 'aoki@example.com', entryDate: '2024-04-01', withdrawDate: '未定', birthDate: '2010-05-14' },

--- a/src/components/regular-template/regularLessonTemplate.test.ts
+++ b/src/components/regular-template/regularLessonTemplate.test.ts
@@ -10,8 +10,6 @@ function createTeacher(overrides: Partial<TeacherRow> = {}): TeacherRow {
     entryDate: '2024-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [],
-    availableSlots: [],
-    memo: '',
     ...overrides,
   }
 }

--- a/src/components/schedule-board/__fixtures__/sampleClassroom.ts
+++ b/src/components/schedule-board/__fixtures__/sampleClassroom.ts
@@ -31,8 +31,6 @@ export const sampleTeachers: TeacherRow[] = [
     entryDate: '2024-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '英', maxGrade: '高3' }],
-    availableSlots: [],
-    memo: '',
   },
   {
     id: 't002',
@@ -41,8 +39,6 @@ export const sampleTeachers: TeacherRow[] = [
     entryDate: '2024-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [{ subject: '英', maxGrade: '高3' }, { subject: '数', maxGrade: '高3' }],
-    availableSlots: [],
-    memo: '',
   },
 ]
 

--- a/src/components/schedule-board/__fixtures__/sampleMakeupStock.ts
+++ b/src/components/schedule-board/__fixtures__/sampleMakeupStock.ts
@@ -24,7 +24,7 @@ function student(id: string, name: string, birthDate: string, overrides: Partial
 }
 
 function teacher(id: string, name: string): TeacherRow {
-  return { id, name, email: `${id}@example.com`, entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '英', maxGrade: '高3' }], availableSlots: [], memo: '' }
+  return { id, name, email: `${id}@example.com`, entryDate: '2024-04-01', withdrawDate: '未定', subjectCapabilities: [{ subject: '数', maxGrade: '高3' }, { subject: '英', maxGrade: '高3' }] }
 }
 
 function regular(overrides: Partial<RegularLessonRow>): RegularLessonRow {

--- a/src/components/schedule-board/makeupStock.test.ts
+++ b/src/components/schedule-board/makeupStock.test.ts
@@ -26,7 +26,6 @@ function createTeacher(overrides: Partial<TeacherRow> = {}): TeacherRow {
     entryDate: '2025-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }],
-    memo: '',
     ...overrides,
   }
 }

--- a/src/components/special-data/SpecialSessionScreen.test.ts
+++ b/src/components/special-data/SpecialSessionScreen.test.ts
@@ -24,7 +24,6 @@ const teachers: TeacherRow[] = [
     entryDate: '2024-04-01',
     withdrawDate: '未定',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }],
-    memo: '',
   },
 ]
 

--- a/src/data/importedMasterData.generated.ts
+++ b/src/data/importedMasterData.generated.ts
@@ -24,7 +24,6 @@ export const importedMasterData = {
         "maxGrade": "小"
       }
     ],
-    "memo": ""
   },
   {
     "id": "01a1f3ea",
@@ -46,7 +45,6 @@ export const importedMasterData = {
         "maxGrade": "高1"
       }
     ],
-    "memo": ""
   },
   {
     "id": "c5286e0f",
@@ -64,7 +62,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "6949c534",
@@ -90,7 +87,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "47a888a9",
@@ -116,7 +112,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "7c8f4166",
@@ -138,7 +133,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "7a966d0d",
@@ -160,7 +154,6 @@ export const importedMasterData = {
         "maxGrade": "高2"
       }
     ],
-    "memo": ""
   },
   {
     "id": "50c0bb23",
@@ -182,7 +175,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "595c8c5c",
@@ -204,7 +196,6 @@ export const importedMasterData = {
         "maxGrade": "高3"
       }
     ],
-    "memo": ""
   },
   {
     "id": "56d79637",
@@ -234,7 +225,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "af07ea65",
@@ -256,7 +246,6 @@ export const importedMasterData = {
         "maxGrade": "高2"
       }
     ],
-    "memo": ""
   },
   {
     "id": "f20678c5",
@@ -286,7 +275,6 @@ export const importedMasterData = {
         "maxGrade": "高3"
       }
     ],
-    "memo": ""
   },
   {
     "id": "6e1b347d",
@@ -308,7 +296,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "431d6982",
@@ -326,7 +313,6 @@ export const importedMasterData = {
         "maxGrade": "高3"
       }
     ],
-    "memo": ""
   },
   {
     "id": "b303a4c6",
@@ -356,7 +342,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "901154b7",
@@ -386,7 +371,6 @@ export const importedMasterData = {
         "maxGrade": "高1"
       }
     ],
-    "memo": ""
   },
   {
     "id": "2d76ee7e",
@@ -416,7 +400,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "5f7cc091",
@@ -430,7 +413,6 @@ export const importedMasterData = {
         "maxGrade": "中"
       }
     ],
-    "memo": ""
   },
   {
     "id": "5ac91303",
@@ -452,7 +434,6 @@ export const importedMasterData = {
         "maxGrade": "高1"
       }
     ],
-    "memo": ""
   }
 ],
   students: [

--- a/src/utils/scheduleHtml.test.ts
+++ b/src/utils/scheduleHtml.test.ts
@@ -26,9 +26,7 @@ function createTeacher(overrides: Partial<TeacherRow> = {}): TeacherRow {
     email: 'teacher@example.com',
     entryDate: '2025-04-01',
     withdrawDate: '未定',
-    memo: '',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }],
-    availableSlots: [],
     ...overrides,
   }
 }

--- a/src/utils/scheduleHtml.ts
+++ b/src/utils/scheduleHtml.ts
@@ -40,7 +40,6 @@ type SerializedTeacher = {
   fullName?: string
   entryDate: string
   withdrawDate: string
-  memo: string
   subjects: string[]
   submissionToken?: string
   qrSvg?: string
@@ -740,7 +739,6 @@ function buildTeacherPayload(params: OpenTeacherScheduleHtmlParams): SchedulePay
         fullName: teacher.name,
         entryDate: teacher.entryDate,
         withdrawDate: teacher.withdrawDate,
-        memo: teacher.memo,
         subjects: teacher.subjectCapabilities.map((capability) => `${capability.subject}${capability.maxGrade}`),
         submissionToken,
         qrSvg: params.lazyQrLoading ? undefined : buildSubmissionQrSvg(submissionToken),
@@ -817,7 +815,6 @@ function buildAllPayload(params: OpenAllScheduleHtmlParams): SchedulePayload {
         fullName: teacher.name,
         entryDate: teacher.entryDate,
         withdrawDate: teacher.withdrawDate,
-        memo: teacher.memo,
         subjects: teacher.subjectCapabilities.map((capability) => `${capability.subject}${capability.maxGrade}`),
         submissionToken,
         qrSvg: params.lazyQrLoading ? undefined : buildSubmissionQrSvg(submissionToken),

--- a/src/utils/specialSessionAvailabilityHtml.test.ts
+++ b/src/utils/specialSessionAvailabilityHtml.test.ts
@@ -24,9 +24,7 @@ function createTeacher(overrides: Partial<TeacherRow> = {}): TeacherRow {
     email: 'teacher@example.com',
     entryDate: '2025-04-01',
     withdrawDate: '未定',
-    memo: '',
     subjectCapabilities: [{ subject: '数', maxGrade: '高3' }],
-    availableSlots: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## 概要
⑥の残り。講師の「出勤可能コマ(availableSlots)」「メモ」を廃止。

## 背景
調査の結果、出勤可能コマは**盤面/日程表に消費されていない保持専用フィールド**（編集できるが使われない）だった。出勤枠はテンプレ管理に統一する方針(spec-basic-data.md)。

## 変更
- TeacherRowから availableSlots・memo を削除。
- 出勤可能コマの機構(型/定数/normalize/serialize/parse/Label)、編集UI(出勤可能コマモーダル・サマリボタン・表列)、Excel列、seed/生成データ、メモ列/入力を一括撤去。
- 関連テストを更新(出勤可能コマ取込テストを削除、メモ期待値を除去)。

## 検証
- `npm run build` 通過 / `npm run test:unit` 261件全通過
- 盤面/日程表への影響なし(未消費フィールドのため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)