### PR TITLE
fix(生徒日程表): 空フォーマット起因の構文エラーで生徒表示が消える不具合を修正

### DIFF
--- a/src/utils/scheduleHtml.test.ts
+++ b/src/utils/scheduleHtml.test.ts
@@ -660,6 +660,49 @@ describe('scheduleHtml buildExpectedRegularOccurrences', () => {
     vi.unstubAllGlobals()
   })
 
+  it('emits a syntactically valid inline client script (guards template-literal escaping bugs)', () => {
+    const write = vi.fn()
+    const popup = {
+      closed: false,
+      document: { open() {}, write, close() {} },
+      focus() {},
+      postMessage() {},
+    } as unknown as Window
+    vi.stubGlobal('window', {
+      open: () => popup,
+      setTimeout: (callback: () => void) => {
+        callback()
+        return 0
+      },
+    })
+
+    openStudentScheduleHtml({
+      cells: [],
+      plannedCells: [],
+      students: [createStudent({ displayName: '山田' })],
+      regularLessons: [],
+      defaultStartDate: '2026-03-24',
+      defaultEndDate: '2026-03-24',
+      titleLabel: 'テスト',
+      classroomSettings: { closedWeekdays: [0], holidayDates: [], forceOpenDates: [] },
+      targetWindow: popup,
+    })
+    const html = write.mock.calls[0]?.[0] as string
+    // Extract every inline <script> block without a src/type attribute (the client logic),
+    // and confirm each parses as valid JS. A template-literal escaping bug (e.g. a stray \\'
+    // that collapses to ') would break parsing here, catching the runtime "blank page" failure.
+    const scriptBlocks = Array.from(
+      html.matchAll(/<script>([\s\S]*?)<\/script>/g),
+      (match) => match[1],
+    )
+    expect(scriptBlocks.length).toBeGreaterThan(0)
+    for (const block of scriptBlocks) {
+      expect(() => new Function(block)).not.toThrow()
+    }
+
+    vi.unstubAllGlobals()
+  })
+
   it('opens print-all schedules into the prepared named popup window', () => {
     const write = vi.fn()
     const popup = {

--- a/src/utils/scheduleHtml.ts
+++ b/src/utils/scheduleHtml.ts
@@ -4151,36 +4151,45 @@ function createScheduleHtml(payload: SchedulePayload, viewType: 'student' | 'tea
         return subjects.map((label) => '<tr><td>' + escapeHtml(label) + '</td><td></td></tr>').join('');
       }
 
+      function applyEmptyFormatBranding(sheetHtml) {
+        var nextHtml = sheetHtml;
+        var schoolValue = readSharedValueForEmptyFormat('school-info');
+        var titleValue = readSharedValueForEmptyFormat('sheet-title') || '授業日程表';
+        var logoValue = readStoredLogoForEmptyFormat();
+        var schoolAnchor = ' data-shared-input="school-info" rows="2" placeholder="校舎名&#10;TEL等"></textarea>';
+        var schoolReplacement = ' data-shared-input="school-info" rows="2" placeholder="校舎名&#10;TEL等">' + escapeHtml(schoolValue) + '</textarea>';
+        nextHtml = nextHtml.replace(schoolAnchor, schoolReplacement);
+        var titleAnchor = 'data-shared-input="sheet-title" value=""';
+        var titleReplacement = 'data-shared-input="sheet-title" value="' + escapeHtml(titleValue) + '"';
+        nextHtml = nextHtml.replace(titleAnchor, titleReplacement);
+        if (logoValue) {
+          var logoAnchor = '<span class="logo-placeholder">ロゴ欄</span>';
+          var logoReplacement = '<img class="logo-image" src="' + logoValue + '" alt="logo" />';
+          nextHtml = nextHtml.replace(logoAnchor, logoReplacement);
+        }
+        return nextHtml;
+      }
+
       function openEmptyFormatPrintWindow() {
-        let startDate = (startInput && startInput.value) || appliedStartDate || DATA.defaultStartDate || DATA.availableStartDate;
-        let endDate = (endInput && endInput.value) || appliedEndDate || DATA.defaultEndDate || DATA.availableEndDate;
+        var startDate = (startInput && startInput.value) || appliedStartDate || DATA.defaultStartDate || DATA.availableStartDate;
+        var endDate = (endInput && endInput.value) || appliedEndDate || DATA.defaultEndDate || DATA.availableEndDate;
         if (startDate > endDate) {
-          const previous = startDate;
+          var previous = startDate;
           startDate = endDate;
           endDate = previous;
         }
-        const result = buildStudentSheetHtml(startDate, endDate, appliedPersonId, 0, true);
+        var result = buildStudentSheetHtml(startDate, endDate, appliedPersonId, 0, true);
         if (!result.html) {
           window.alert('空フォーマットを作成できる生徒が見つかりません。');
           return;
         }
-        const styleHtml = Array.from(document.querySelectorAll('style')).map((element) => element.outerHTML).join('');
-        const branding = {
-          logo: readStoredLogoForEmptyFormat(),
-          school: readSharedValueForEmptyFormat('school-info'),
-          title: readSharedValueForEmptyFormat('sheet-title') || '授業日程表',
-        };
-        const printWindow = window.open('', 'schedule-empty-format-' + Date.now());
+        var sheetHtml = applyEmptyFormatBranding(result.html);
+        var styleHtml = Array.from(document.querySelectorAll('style')).map((element) => element.outerHTML).join('');
+        var printWindow = window.open('', 'schedule-empty-format-' + Date.now());
         if (!printWindow) return;
-        const bootstrapScript = '<scr' + 'ipt>(function(){'
-          + 'var d=' + JSON.stringify(branding).replace(/</g, '\\u003c') + ';'
-          + 'try{document.querySelectorAll("textarea.school-input").forEach(function(el){el.value=d.school;});}catch(e){}'
-          + 'try{document.querySelectorAll("input.title-input").forEach(function(el){el.value=d.title;});}catch(e){}'
-          + 'try{if(d.logo){document.querySelectorAll(\'[data-shared-image="logo"]\').forEach(function(el){el.innerHTML=\'<img class="logo-image" src="\'+d.logo+\'" alt="logo" />\';});}}catch(e){}'
-          + 'window.addEventListener("load",function(){setTimeout(function(){window.focus();window.print();},300);});'
-          + '})();</scr' + 'ipt>';
+        var printScript = '<scr' + 'ipt>window.addEventListener("load",function(){setTimeout(function(){window.focus();window.print();},300);});</scr' + 'ipt>';
         printWindow.document.open();
-        printWindow.document.write('<!doctype html><html lang="ja"><head><meta charset="UTF-8" /><title>空フォーマット印刷</title>' + styleHtml + '</head><body class="all-view">' + result.html + bootstrapScript + '</body></html>');
+        printWindow.document.write('<!doctype html><html lang="ja"><head><meta charset="UTF-8" /><title>空フォーマット印刷</title>' + styleHtml + '</head><body class="all-view">' + sheetHtml + printScript + '</body></html>');
         printWindow.document.close();
       }
 


### PR DESCRIPTION
## 不具合
`空フォーマット印刷` 追加後、生徒日程表で**生徒表示・講習期間・生徒選択が表示されず、ボタンも無反応**になっていた。

## 原因
`openEmptyFormatPrintWindow` のブートストラップ文字列に `\'`（エスケープしたシングルクォート）を使用。クライアントスクリプト全体はソースの**テンプレートリテラル内**にあるため、`\'` がテンプレートリテラルに評価されて素の `'` になり、出力された JS の文字列リテラルが途中で閉じて**構文エラー**化。結果スクリプト全体が実行されず初期化が止まっていた。（ビルドは文字列内のため検知できず）

## 修正
- ブートストラップ印字をやめ、ロゴ／教室名欄／タイトルは**ソース側の文字列置換**で注入する方式に変更（入れ子シングルクォート不要）。
- 回帰防止に、生成された埋め込み `<script>` を `new Function` で**構文検証**するユニットテストを追加。

## テスト
- `npm run build` 成功 / `scheduleHtml.test.ts` 全38件パス（構文検証テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)