### PR TITLE
Phase6 ⑧自動割振: TODO5/4/3/2/1 (ペア制約2区分・groupLessons空・指定時限禁止・時限優先スライダー・区分許可リスト)

### DIFF
--- a/docs/NEXT-SESSION-PROMPT.md
+++ b/docs/NEXT-SESSION-PROMPT.md
@@ -1,0 +1,33 @@
+# 次セッション用プロンプト（コピペ用）
+
+> 下の「---」以降をそのまま新しいチャットに貼り付けてください。
+
+---
+
+コマ表アプリ（本番稼働中・複数教室）の段階的実装を継続します。まず `docs/SESSION-HANDOFF.md` を読んでから着手して。
+
+## 現在地（2026-06-10 時点）
+- 本番 = **v1.5.291**（main 同期）。Phase 0〜5 ＋ テンプレ挙動デルタ まで本番反映済み。
+- いま **Phase 6（最終）** の途中。
+  - **⑧ 自動割振**：ブランチ `phase6-auto-assign`（push済・**未マージ・未デプロイ**）に
+    - ✅ TODO5 ペア制約2区分／✅ TODO4 groupLessons種データ空／✅ TODO3 指定時限禁止スライダー（build/test:unit 272 グリーン）
+    - ⏳ TODO2 時限優先スライダー（3ルール統合＋並べ替えUI＋スコア書換）
+    - ⏳ TODO1 区分許可リスト（全ルールへ category＋許可リスト、`forcedRuleKeys`置換、グルーピング再構成）
+    - TODO2/TODO1 は相互依存・最重量。詳細＝`docs/spec-auto-assign-rules.md` 実装状況。
+  - **② 保存クラウド一本化 本体**：未着手・**最高リスク**（保存アーキ＝クロス汚染事故領域）。詳細＝`docs/spec-save-restore.md`。
+
+## 最初にやること（どれかを私に確認してから進めて）
+A. **`phase6-auto-assign` を PR→マージ→デプロイ**して TODO5/4/3 を先に本番反映（推奨の区切り）。
+   - 手順：`gh pr create --base main --head phase6-auto-assign ...` → `gh pr merge --merge` → `git checkout main && git pull` → package.json の version を上げる（1.5.291→1.5.292）→ commit/push → `npm run deploy:firebase`（functions変更が無ければ functions 無しで可。⑧は functions 不変なので通常 `deploy:firebase` でOK）→ live検証。
+B. **⑧ TODO2/TODO1 を同ブランチで続行**（一体設計）。`AutoAssignRuleScreen.tsx`（区分グルーピング/renderRuleCard）＋ `ScheduleBoardScreen.tsx`（時限スコアリング L4211-4248）＋ `autoAssignRuleModel.ts`。
+C. **② に着手**するなら**現状精査を最優先**（Phase0/2 で多くが実装済の可能性大。既存充足を見極める）。書込検証は開発用教室 `v8OZ7zH8vONNHjjYVcR1` のみ。
+
+## 厳守ルール（重要）
+- **本番3教室（日大前/緑が丘/薬円台）は読み取り専用**。Firestoreへの書込検証は**開発用教室 `v8OZ7zH8vONNHjjYVcR1` のみ**。復元/コピー系 Functions を本番に向けない（`CLAUDE.md`）。
+- **着手前に必ず現状精査**（Phase 3/4/5/⑧ 同様、核心が既に実装済みのことが多い）。
+- **改行コードの罠**：`src/components/schedule-board/__snapshots__/makeupStockSnapshot.test.ts.snap` は git 操作のたび LF/CRLF だけの差分で誤検知される。内容無変更なら `git checkout --` で戻す。コミットは**対象ファイルを明示**して add（`CLAUDE.md`/`.claude/` を巻き込まない）。原則 Edit ツールで編集（`sed -i` はCR剥がしで全行差分になる）。
+- 検証：`npm run build`／`npm run test:unit`（現在 272 件）。コミット/PR/デプロイは**オーナーの指示があってから**。
+
+## 参照
+- 正本目次 `docs/spec-index.md`、計画 `docs/spec-implementation-plan.md`。
+- メモリ：保存アーキ `memory/komahyou-save-architecture.md`、クロス汚染 `memory/komahyou-classroom-restore-cross-contamination.md`、テンプレ編集フロー `memory/komahyou-template-editing-flow.md`、scheduleHtml埋め込みJSの罠 `memory/komahyou-schedulehtml-embedded-script.md`。

--- a/docs/SESSION-HANDOFF.md
+++ b/docs/SESSION-HANDOFF.md
@@ -1,25 +1,28 @@
-# セッション引き継ぎ資料（2026-06-09 時点）
+# セッション引き継ぎ資料（2026-06-10 時点）
 
 新しいチャットはまずこのファイルを読む。プロジェクト「コマ表アプリ」の**全体見直し→段階的実装**を継続中。
 
 ---
 
-## 0. いま何をしているか（最重要・即時タスク）
+## 0. いま何をしているか（最重要・即時タスク）※2026-06-10 更新
 
-**Phase 5（⑤講習ストック/⑦提出/⑨日程表）＋テンプレ挙動デルタ＝完了・2026-06-09 にデプロイ（v1.5.291）。** 本番＝main 同期（PR #23 マージ済）。
-→ **次は Phase 6**（②クラウド一本化本体／⑧自動割振スライダー化・区分許可リスト）。**着手前に必ず現状精査**（Phase 3/4/5 同様、核心が既に実装済みの可能性大）。②は保存アーキテクチャに触れる最高リスク領域（`memory/komahyou-save-architecture.md` 参照）。
+**本番＝v1.5.291（main 同期）。Phase 0〜5 ＋ テンプレ挙動デルタ まで本番反映済み。**
+いまは **Phase 6（最終フェーズ）** を実装中。
 
-（履歴）Phase 4（振替 A/B/C）完了・2026-06-09 デプロイ（v1.5.290）。
+### Phase 6 の状態
+- **⑧ 自動割振ルール**：ブランチ `phase6-auto-assign`（**push済・未マージ・未デプロイ**, main の5コミット先）に下記を実装。build・typecheck・test:unit(272) グリーン。
+  - ✅ **TODO5 ペア制約2区分**（`category` 既定=制約／優先。`pairConstraint.ts`＋`resolvePairConstraintSeverity`＋UI区分トグル＋Excel）
+  - ✅ **TODO4 groupLessons 種データ空**（`initialGroupLessons=[]`。型/配管は維持＝オーナー判断）
+  - ✅ **TODO3 指定時限禁止スライダー**（`forbidFirstPeriod`一般化→`forbiddenPeriods`既定[1]。1〜5限トグルUI＋スコア/警告＋Excel）
+  - ⏳ **TODO2 時限優先スライダー**（preferLateAfternoon/Second/Fifth 3ルール統合＋並べ替えUI＋スコア書換）
+  - ⏳ **TODO1 区分許可リスト**（全ルールへ category＋allowedCategories、`forcedRuleKeys`置換、ルール表示のグルーピング再構成。最も波及大）
+  - ※ TODO2/TODO1 は相互依存・最重量。一体設計推奨。詳細＝`docs/spec-auto-assign-rules.md` 実装状況。
+- **② クラウド一本化（保存・復元）本体**：**未着手・最高リスク**（保存アーキ＝クロス汚染事故領域）。残＝二段階保存廃止/復元UI整理/開発用コピー室長開放。多くは Phase0/2 で実装済（5s/20s・常時緑・オフラインブロック・JSON復元）。詳細＝`docs/spec-save-restore.md`。
 
-→ **再開時の次タスク候補**：
-1. **テンプレ挙動の仕様＝確定済み（2026-06-09 正本化）＋実装デルタ完了（2026-06-09・未デプロイ）**：`docs/spec-template-behavior.md` 参照。Q1-Q20 の 5件のデルタを実装済（build/test:unit 266件グリーン・**未コミット/未デプロイ**）：
-   - **Q4** ✅ 定休日に講師・生徒を配置不可。**稼働中は ScheduleBoardScreen のオンボード template モード**が本体（`RegularLessonTemplateEditor.tsx` は死蔵）。両方にブロック追加。
-   - **Q11** ✅ `maxSchoolYear=2031` 多年度ループを撤廃 → 反映日〜当年度末(3/31)の単年度のみ生成。
-   - **Q14** ✅ 精査で**オンボード配置ロスターは既に入会前を許可済**。`filterTemplateParticipantsForReferenceDate` 講師フィルタのみ `!=='退塾'` に統一。
-   - **Q16** ✅ `regularLessonTemplateHistory` を `.slice(-3)`。
-   - **Q17** ✅ 変更不要（UI からは `overwrite=true` のみ呼ばれ既に1本。内部引数は保持）。
-   - → **次**：コミット/PR → 開発用教室で動作確認 → version 上げてデプロイ。`RegularLessonTemplateEditor.tsx` 死蔵の整理は別途検討。
-2. Phase 5（⑤講習ストック／⑦提出／⑨日程表）・Phase 6（②クラウド一本化本体／⑧自動割振）。
+### 次セッションの最初の判断
+1. **⑧ の `phase6-auto-assign` を PR→マージ→デプロイ**して本番反映するか（TODO5/4/3 を先に出す）、
+2. それとも **⑧ TODO2/TODO1 を同ブランチで続け**てから一括で出すか。
+3. ② に着手するなら**現状精査を最優先**（既存充足を見極めてから・開発用教室でのみ書込検証）。
 
 ### このセッションの完了事項（2026-06-09）
 - **Phase 4-B 欠席登録UI＝実装済みと精査確認**（PR #16）。下記詳細参照。

--- a/docs/spec-auto-assign-rules.md
+++ b/docs/spec-auto-assign-rules.md
@@ -101,6 +101,9 @@
   - `AutoAssignRuleScreen.tsx`：追加フォーム＋一覧に「区分」トグル、Excel入出力に「区分」列。
   - テスト：`pairConstraint.test.ts`（既定=制約/優先の解決）。
 - **TODO4（groupLessons 整理）✅ 実装（未デプロイ）**：`initialGroupLessons` のサンプル種データを空配列に（型・スナップショット配管は維持＝オーナー判断）。
-- **残（未着手）**：TODO1（区分許可リスト）/ TODO2・3（時限スライダー）。いずれも割振スコアリング・新データモデルに波及するため別増分。
+- **TODO3（指定時限禁止スライダー）✅ 実装（未デプロイ）**：`forbidFirstPeriod` を一般化。`forbiddenPeriods?:number[]`＋`resolveForbiddenPeriods`（未設定=[1]）。ルールカードに1〜5限トグル、割振スコア／警告を forbiddenPeriods で判定、Excel「禁止時限」列、ラベル「指定時限禁止」。テスト追加。
+- **残（未着手）**：
+  - **TODO2（時限優先スライダー）**：preferLateAfternoon/Second/Fifth の3ルール統合。`periodPriorityOrder` 等の順序データ＋並べ替えUI＋スコアリング。UIが重め＋冗長ルールの非表示判断で TODO1 と一部重複。
+  - **TODO1（区分許可リスト）**：全ルールに category＋allowedCategories を導入し forcedRuleKeys 置換。ルールのグルーピング表示の再構成を伴い最も波及大。
 
 > いずれもアルゴリズム層（ScheduleBoardScreen の複雑な割振）に波及。増分ごとに開発用教室で検証、ゴールデンスナップショット更新の可能性。`autoAssignRuleModel.test.ts` に区分/許可リストの検証を追加。

--- a/docs/spec-auto-assign-rules.md
+++ b/docs/spec-auto-assign-rules.md
@@ -102,8 +102,18 @@
   - テスト：`pairConstraint.test.ts`（既定=制約/優先の解決）。
 - **TODO4（groupLessons 整理）✅ 実装（未デプロイ）**：`initialGroupLessons` のサンプル種データを空配列に（型・スナップショット配管は維持＝オーナー判断）。
 - **TODO3（指定時限禁止スライダー）✅ 実装（未デプロイ）**：`forbidFirstPeriod` を一般化。`forbiddenPeriods?:number[]`＋`resolveForbiddenPeriods`（未設定=[1]）。ルールカードに1〜5限トグル、割振スコア／警告を forbiddenPeriods で判定、Excel「禁止時限」列、ラベル「指定時限禁止」。テスト追加。
-- **残（未着手）**：
-  - **TODO2（時限優先スライダー）**：preferLateAfternoon/Second/Fifth の3ルール統合。`periodPriorityOrder` 等の順序データ＋並べ替えUI＋スコアリング。UIが重め＋冗長ルールの非表示判断で TODO1 と一部重複。
-  - **TODO1（区分許可リスト）**：全ルールに category＋allowedCategories を導入し forcedRuleKeys 置換。ルールのグルーピング表示の再構成を伴い最も波及大。
+- **TODO2（時限優先スライダー）✅ 実装（未デプロイ）**：
+  - `autoAssignRuleModel.ts`：`periodPriorityOrder?:number[]`＋`resolvePeriodPriorityOrder`（未設定=[5,4,3,2,1]＝旧「3,4,5限優先」。欠けは既定順で補完し常に1〜5全時限の並びに正規化）。`preferLateAfternoon` を「時限優先」へ改称・定義一本化（`preferSecondPeriod`/`preferFifthPeriod` は定義から削除、型 union は旧スナップショット互換で残置＝対象なし運用）。
+  - `ScheduleBoardScreen.tsx`：`lectureConstraintGroupDefinitions` time-preference を `['preferLateAfternoon']` に集約。`buildCommonAutoAssignScoreParts` の時限スコアを優先順ランクで算出（index0 が最高得点）。ルール未設定時は従来どおり遅い時限優先のまま。
+  - `AutoAssignRuleScreen.tsx`：時限優先カードに 1〜5限の並べ替えUI（上へ/下へ）。Excel「優先時限順」列の入出力。
+  - テスト：`resolvePeriodPriorityOrder`（既定/補完/範囲外除外）。
+- **TODO1（区分許可リスト）✅ 実装（未デプロイ・挙動はソフト維持）**：
+  - `autoAssignRuleModel.ts`：`AutoAssignRuleCategory='priority'|'constraint'`＋`AutoAssignRuleRow.category?`。許可リスト `getAllowedRuleCategories`（制約可＝コマ数上限/指定時限禁止/科目対応講師のみ/通常講師のみ。他は優先のみ）＋`getDefaultRuleCategory`（既定＝旧 forcedRuleKeys：指定時限禁止/科目対応講師のみ/通常講師のみ＝制約、コマ数上限＝優先）＋`resolveRuleCategory`（許可外/未設定は既定へ丸め）。
+  - `AutoAssignRuleScreen.tsx`：ハードコード `forcedRuleKeys` を `resolveRuleCategory==='constraint'` へ置換。制約事項セクション＝区分=制約のルール、優先事項グループ＝区分=優先のみ表示（全て制約へ移ったグループは非表示）。各ルールカードに区分トグル（許可リスト内のみ）。`moveRuleGroup` を区分移動に伴う重複排除＋残置キー保全に対応。Excel「分類」列を取り込み（許可外は丸め）。
+  - `ScheduleBoardScreen.tsx`：盤面の赤字警告ラベル（科目対応講師のみ/指定時限禁止/通常講師のみ）を区分に応じて「制約事項/優先事項」へ切替。**割振アルゴリズム自体は不変（区分=制約でもハードフィルタ化しない＝オーナー確認済みの方針／本番割振結果を変えない）。**
+  - テスト：`getAllowedRuleCategories`/`getDefaultRuleCategory`/`resolveRuleCategory`（許可リスト・既定・丸め）。
+- **残（オーナー判断）**：
+  - 区分=制約事項を将来「ハードフィルタ化」するか（現状はソフト＝強い減点＋赤字警告のまま）。spec B「必ず守る＝ハード」に厳密化する場合は本番割振の再検証＋ゴールデンスナップショット更新が必要。
+  - 旧「2限寄り/5限寄り」を明示設定していた教室の自動移行（現状は未移行＝既定の遅い時限優先へ戻る。時限優先は再設定で対応）。
 
-> いずれもアルゴリズム層（ScheduleBoardScreen の複雑な割振）に波及。増分ごとに開発用教室で検証、ゴールデンスナップショット更新の可能性。`autoAssignRuleModel.test.ts` に区分/許可リストの検証を追加。
+> アルゴリズム層（ScheduleBoardScreen）の割振挙動は TODO2 の時限スコア式のみ変化（ルール未設定時の既定は不変）。TODO1 は区分のソフト扱いを維持し割振結果を変えない。検証＝build／test:unit（278件グリーン）。書込検証は開発用教室のみ。

--- a/docs/spec-auto-assign-rules.md
+++ b/docs/spec-auto-assign-rules.md
@@ -72,3 +72,25 @@
 4. **グループ授業（`groupLessons`/班）を整理**（編集UIは元々無し。種データを空に or フィールドごと撤去）。
    ※ `origin: 'group-conflict'`（ルール相互排他）は別機能なので**残す**。
 5. ペア制約の区分を 優先/制約 の2区分へ（既定＝制約事項）。
+
+## 現状精査（2026-06-09・Phase 6 ⑧ 着手前）
+
+- **区分は未モデル化**：`AutoAssignRuleRow` に category フィールド無し。区分は `AutoAssignRuleScreen.tsx` の
+  `forcedRuleKeys = {forbidFirstPeriod, regularTeachersOnly, subjectCapableTeachersOnly}`（ハードコードSet）で
+  「制約事項」、残りを「優先事項」として描画。絶対事項はアプリ固定テキスト（既存コマ不変／出席可能コマのみ）。
+  - 注意: spec C では「同日コマ数上限(maxOne/Two/Three)」は制約事項に選べる想定だが、現状は優先事項(soft)のみ。
+- **時限ルールは4つの個別キー**：`preferLateAfternoon`/`preferSecondPeriod`/`preferFifthPeriod`（優先順位グループ orderKey=preferLateAfternoon に統合済の表示）＋ `forbidFirstPeriod`。スライダー用の範囲/順序データモデルは無し。
+- **ペア制約 `PairConstraintRow`**：`{personA/B, type:'incompatible'}` のみ。category 無し（現状は常にハード）。
+- **割振アルゴリズム本体**は `ScheduleBoardScreen.tsx`（`lectureConstraintGroupDefinitions` ほか）。区分・スライダーの判定はここが参照する。
+
+### 実装計画（増分・各層）
+
+| TODO | モデル | UI(AutoAssignRuleScreen) | アルゴリズム(ScheduleBoardScreen) | 備考/要確認 |
+|---|---|---|---|---|
+| 1 区分許可リスト | `category:'priority'|'constraint'` を AutoAssignRuleRow に追加＋ルール別 `allowedCategories` メタ＋既定値。sanitize/移行で既定補完 | 各ルールに区分トグル（許可リスト内のみ）。絶対事項は固定表示 | `forcedRuleKeys` ハードコードを `rule.category==='constraint'` 判定へ置換 | 許可リスト割当（どのルールが制約可か）を最終確認 |
+| 2 時限優先スライダー | 時限優先の範囲/順序を表す新データ（例 `timePreferenceOrder:number[]`）。旧3キーは「対象なし運用」or 1キーへ集約 | 1〜5限のスライダー/並べ替えUI | スコアリングを新データで算出 | 旧3ルールの後方互換（既存データ移行）を確認 |
+| 3 指定時限禁止スライダー | `forbidFirstPeriod` を `forbiddenPeriods:number[]` 一般化 | 1〜5限トグル/スライダー | フィルタを forbiddenPeriods で判定 | 既存「1限禁止」を [1] に移行 |
+| 4 groupLessons 整理 | 種データを空 or 型ごと撤去 | （UI無し） | スナップショット配管 | **撤去の深さは要オーナー判断**（§G） |
+| 5 ペア制約2区分 | `PairConstraintRow.category:'priority'|'constraint'`（既定 constraint、移行で補完） | A/B選択UIに区分トグル | ペア制約の enforcement を hard/soft 分岐 | 既定=制約で現挙動維持 |
+
+> いずれもアルゴリズム層（ScheduleBoardScreen の複雑な割振）に波及。増分ごとに開発用教室で検証、ゴールデンスナップショット更新の可能性。`autoAssignRuleModel.test.ts` に区分/許可リストの検証を追加。

--- a/docs/spec-auto-assign-rules.md
+++ b/docs/spec-auto-assign-rules.md
@@ -93,4 +93,14 @@
 | 4 groupLessons 整理 | 種データを空 or 型ごと撤去 | （UI無し） | スナップショット配管 | **撤去の深さは要オーナー判断**（§G） |
 | 5 ペア制約2区分 | `PairConstraintRow.category:'priority'|'constraint'`（既定 constraint、移行で補完） | A/B選択UIに区分トグル | ペア制約の enforcement を hard/soft 分岐 | 既定=制約で現挙動維持 |
 
+## 実装状況（2026-06-09・Phase 6 ⑧ 着手・phase6-auto-assign ブランチ）
+
+- **TODO5（ペア制約2区分）✅ 実装（未デプロイ）**：
+  - `pairConstraint.ts`：`category?:'priority'|'constraint'`（optional・後方互換）＋ `resolvePairConstraintCategory`（未設定=constraint）。
+  - `ScheduleBoardScreen.tsx`：`resolvePairConstraintSeverity`（none/priority/constraint・複数一致は強い方）。制約=赤の「制約: 組み合わせ不可」、優先=非赤の「優先: 組み合わせ回避」。自動割振スコアは両方とも回避方向（`isPairConstraintBlocked` は severity!=='none'）。
+  - `AutoAssignRuleScreen.tsx`：追加フォーム＋一覧に「区分」トグル、Excel入出力に「区分」列。
+  - テスト：`pairConstraint.test.ts`（既定=制約/優先の解決）。
+- **TODO4（groupLessons 整理）✅ 実装（未デプロイ）**：`initialGroupLessons` のサンプル種データを空配列に（型・スナップショット配管は維持＝オーナー判断）。
+- **残（未着手）**：TODO1（区分許可リスト）/ TODO2・3（時限スライダー）。いずれも割振スコアリング・新データモデルに波及するため別増分。
+
 > いずれもアルゴリズム層（ScheduleBoardScreen の複雑な割振）に波及。増分ごとに開発用教室で検証、ゴールデンスナップショット更新の可能性。`autoAssignRuleModel.test.ts` に区分/許可リストの検証を追加。

--- a/src/App.css
+++ b/src/App.css
@@ -2757,6 +2757,14 @@ tr.sa-slot-last th {
   gap: 8px;
 }
 
+.auto-assign-rule-period-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0;
+}
+
 .auto-assign-rule-summary {
   display: -webkit-box;
   overflow: hidden;

--- a/src/App.css
+++ b/src/App.css
@@ -2765,6 +2765,63 @@ tr.sa-slot-last th {
   margin: 6px 0;
 }
 
+/* ⑧TODO1: 区分（優先/制約）切替 */
+.auto-assign-rule-category-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: 12px;
+  color: #36506d;
+}
+
+.auto-assign-rule-category-row select {
+  font-size: 12px;
+}
+
+/* ⑧TODO2: 時限優先の並べ替え */
+.auto-assign-rule-period-order {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 6px 0;
+}
+
+.auto-assign-period-order-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.auto-assign-period-order-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auto-assign-period-order-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e2ebf5;
+  color: #36506d;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.auto-assign-period-order-label {
+  min-width: 36px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #243b57;
+}
+
 .auto-assign-rule-summary {
   display: -webkit-box;
   overflow: hidden;

--- a/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
+++ b/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
@@ -5,9 +5,13 @@ import {
   autoAssignPeriodOptions,
   autoAssignRuleDefinitions,
   createAutoAssignTargetId,
+  getAllowedRuleCategories,
   listAutoAssignTargetGrades,
   resolveForbiddenPeriods,
+  resolvePeriodPriorityOrder,
+  resolveRuleCategory,
   resolveStudentGradeLabel,
+  type AutoAssignRuleCategory,
   type AutoAssignRuleKey,
   type AutoAssignRuleRow,
   type AutoAssignTarget,
@@ -31,10 +35,10 @@ type AutoAssignRuleScreenProps = {
 
 type TargetDraftType = 'all' | 'grade' | 'students'
 type SelectionModalMode = 'target' | 'exclude'
-type RuleGroupKey = 'day-spacing' | 'two-students' | 'lesson-limit' | 'lesson-pattern' | 'time-preference'
+type RuleGroupKey = 'day-spacing' | 'two-students' | 'lesson-limit' | 'lesson-pattern' | 'time-preference' | 'subject-capable' | 'regular-teachers' | 'forbid-period'
 type XlsxModule = typeof import('xlsx')
 
-const forcedRuleKeys = new Set<AutoAssignRuleKey>(['forbidFirstPeriod', 'regularTeachersOnly', 'subjectCapableTeachersOnly'])
+// ⑧TODO1: 区分は rule.category で解決（resolveRuleCategory）。制約事項=section/警告/Excel の区分表示に使う。
 const singleTargetRuleKeys = new Set<AutoAssignRuleKey>(['maxOneLesson', 'maxTwoLessons', 'maxThreeLessons'])
 const fixedAbsoluteConstraints = [
   {
@@ -91,9 +95,31 @@ const ruleGroupDefinitions: Array<{
   {
     key: 'time-preference',
     label: '時限優先',
-    description: '3,4,5限優先 / 2限寄り / 5限寄りをひとかたまりとして優先順位を付けます。',
+    description: '優先する時限の順番を 1〜5 限で並べ替えて優先順位を付けます。',
     orderKey: 'preferLateAfternoon',
-    ruleKeys: ['preferLateAfternoon', 'preferSecondPeriod', 'preferFifthPeriod'],
+    ruleKeys: ['preferLateAfternoon'],
+  },
+  // ⑧TODO1: 制約可ルールを優先事項へ切り替えたとき、優先事項セクションに表示する受け皿（既定は制約事項のため非表示）。
+  {
+    key: 'subject-capable',
+    label: '科目対応講師のみ',
+    description: '講師の科目担当に収まる生徒だけを配置候補にします。',
+    orderKey: 'subjectCapableTeachersOnly',
+    ruleKeys: ['subjectCapableTeachersOnly'],
+  },
+  {
+    key: 'regular-teachers',
+    label: '通常講師のみ',
+    description: '割振りを通常授業で担当している講師だけに制限します。',
+    orderKey: 'regularTeachersOnly',
+    ruleKeys: ['regularTeachersOnly'],
+  },
+  {
+    key: 'forbid-period',
+    label: '指定時限禁止',
+    description: '対象者を、指定した時限に配置しないよう制限します。',
+    orderKey: 'forbidFirstPeriod',
+    ruleKeys: ['forbidFirstPeriod'],
   },
 ]
 
@@ -218,12 +244,14 @@ export function buildAutoAssignWorkbook(
 ) {
   const workbook = xlsx.utils.book_new()
 
-  xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, rules.map((rule, index) => ({
+  const knownRuleKeys = new Set(autoAssignRuleDefinitions.map((definition) => definition.key))
+  xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, rules.filter((rule) => knownRuleKeys.has(rule.key)).map((rule, index) => ({
     並び順: index + 1,
     ルールキー: rule.key,
     ルール名: rule.label,
-    分類: forcedRuleKeys.has(rule.key) ? '制約事項' : '優先事項',
+    分類: resolveRuleCategory(rule) === 'constraint' ? '制約事項' : '優先事項',
     禁止時限: rule.key === 'forbidFirstPeriod' ? resolveForbiddenPeriods(rule).join(',') : '',
+    優先時限順: rule.key === 'preferLateAfternoon' ? resolvePeriodPriorityOrder(rule).join(',') : '',
     対象: serializeAutoAssignTargets(rule.targets, studentNameById),
     対象外: serializeAutoAssignTargets(rule.excludeTargets, studentNameById),
   }))), 'ルール')
@@ -240,6 +268,9 @@ export function buildAutoAssignWorkbook(
   xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, [
     { 項目: '対象/対象外', 説明: 'all または grade:中1 または students:青木太郎,伊藤花 を | 区切りで並べます。' },
     { 項目: 'ルールキー', 説明: 'current 出力のルールキーをそのまま使ってください。未知のキーは取り込みません。' },
+    { 項目: '分類', 説明: '制約事項 / 優先事項 を入力します。コマ数上限・指定時限禁止・科目対応講師のみ・通常講師のみ だけ制約事項にできます。他は優先事項に丸めます。' },
+    { 項目: '禁止時限', 説明: '指定時限禁止ルールの禁止する時限を 1〜5 のカンマ区切りで入力します（例 1,2）。' },
+    { 項目: '優先時限順', 説明: '時限優先ルールの優先順を 1〜5 で並べます（例 5,4,3,2,1）。先頭ほど優先します。' },
     { 項目: 'ペア制約', 説明: '人物A/B は種別に応じて講師名または生徒名で入力します。' },
     { 項目: '固定の絶対事項', 説明: '既存コマは変更しない / 出席可能コマのみ はアプリ固定のため Excel では編集しません。' },
   ]), '説明')
@@ -273,6 +304,11 @@ export function parseAutoAssignWorkbook(
           const forbiddenPeriods = key === 'forbidFirstPeriod'
             ? resolveForbiddenPeriods({ forbiddenPeriods: normalizeText(row['禁止時限']).split(/[,、\s]+/).map((value) => Number(value)).filter((value) => Number.isFinite(value)) })
             : undefined
+          const periodPriorityOrder = key === 'preferLateAfternoon'
+            ? resolvePeriodPriorityOrder({ periodPriorityOrder: normalizeText(row['優先時限順']).split(/[,、\s＞>]+/).map((value) => Number(value)).filter((value) => Number.isFinite(value)) })
+            : undefined
+          const requestedCategory: AutoAssignRuleCategory = normalizeText(row['分類']) === '制約事項' ? 'constraint' : 'priority'
+          const category = resolveRuleCategory({ key, category: requestedCategory })
 
           return {
             order: Number(row['並び順']) || index + 1,
@@ -281,7 +317,9 @@ export function parseAutoAssignWorkbook(
               targets: parseAutoAssignTargets(row['対象'], studentIdByName),
               excludeTargets: parseAutoAssignTargets(row['対象外'], studentIdByName),
               priorityScore: 3,
+              category,
               ...(forbiddenPeriods ? { forbiddenPeriods } : {}),
+              ...(periodPriorityOrder ? { periodPriorityOrder } : {}),
               includeStudentIds: [],
               excludeStudentIds: [],
               updatedAt: timestamp,
@@ -370,15 +408,17 @@ export function AutoAssignRuleScreen({
   const studentGradeById = useMemo(() => Object.fromEntries(visibleStudents.map((student) => [student.id, resolveStudentGradeLabel(student.birthDate, referenceDate)])), [referenceDate, visibleStudents])
   const gradeOptions = useMemo(() => listAutoAssignTargetGrades(visibleStudents, referenceDate), [referenceDate, visibleStudents])
   const normalizedRules = useMemo(() => rules.map(normalizeRule), [rules])
-  const forcedRules = useMemo(() => normalizedRules.filter((rule) => forcedRuleKeys.has(rule.key)), [normalizedRules])
+  const forcedRules = useMemo(() => normalizedRules.filter((rule) => resolveRuleCategory(rule) === 'constraint'), [normalizedRules])
+  // ⑧TODO1: 優先事項グループは区分=優先のルールだけを表示し、全て制約事項へ移ったグループは隠す。
   const orderedRuleGroups = useMemo(() => ruleGroupDefinitions
     .map((group) => ({
       ...group,
       rules: group.ruleKeys
         .map((ruleKey) => normalizedRules.find((rule) => rule.key === ruleKey))
-        .filter((rule): rule is AutoAssignRuleRow => Boolean(rule)),
+        .filter((rule): rule is AutoAssignRuleRow => Boolean(rule) && resolveRuleCategory(rule) === 'priority'),
       firstIndex: normalizedRules.findIndex((rule) => rule.key === group.orderKey),
     }))
+    .filter((group) => group.rules.length > 0)
     .sort((left, right) => left.firstIndex - right.firstIndex),
   [normalizedRules])
 
@@ -584,6 +624,27 @@ export function AutoAssignRuleScreen({
     }), '指定時限禁止の時限を更新しました。')
   }
 
+  // ⑧TODO1: ルールの区分（優先事項／制約事項）を切り替える。許可リスト外は無視。
+  const setRuleCategory = (ruleKey: AutoAssignRuleKey, category: AutoAssignRuleCategory) => {
+    if (!getAllowedRuleCategories(ruleKey).includes(category)) return
+    updateRules((current) => current.map((rule) => rule.key === ruleKey ? { ...rule, category } : rule),
+      category === 'constraint' ? '区分を制約事項に変更しました。' : '区分を優先事項に変更しました。')
+  }
+
+  // ⑧TODO2: 時限優先スライダー。優先順を1つずつ上下に入れ替える。
+  const movePeriodPriority = (ruleKey: AutoAssignRuleKey, period: number, direction: 'up' | 'down') => {
+    updateRules((current) => current.map((rule) => {
+      if (rule.key !== ruleKey) return rule
+      const order = resolvePeriodPriorityOrder(rule)
+      const currentIndex = order.indexOf(period)
+      const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
+      if (currentIndex < 0 || targetIndex < 0 || targetIndex >= order.length) return rule
+      const nextOrder = [...order]
+      ;[nextOrder[currentIndex], nextOrder[targetIndex]] = [nextOrder[targetIndex], nextOrder[currentIndex]]
+      return { ...rule, periodPriorityOrder: nextOrder }
+    }), '時限優先の順番を更新しました。')
+  }
+
   const moveRuleGroup = (groupKey: RuleGroupKey, direction: 'up' | 'down') => {
     const currentIndex = orderedRuleGroups.findIndex((group) => group.key === groupKey)
     const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
@@ -594,15 +655,18 @@ export function AutoAssignRuleScreen({
 
     updateRules((current) => {
       const byRuleKey = new Map(current.map((rule) => [rule.key, rule]))
-      const nextForcedRules = current.filter((rule) => forcedRuleKeys.has(rule.key))
+      const nextForcedRules = current.filter((rule) => resolveRuleCategory(rule) === 'constraint')
+      const forcedKeySet = new Set(nextForcedRules.map((rule) => rule.key))
       const nextGroupedRules = nextGroupOrder.flatMap((currentGroupKey) => {
         const groupDefinition = ruleGroupDefinitions.find((group) => group.key === currentGroupKey)
         if (!groupDefinition) return []
         return groupDefinition.ruleKeys
           .map((ruleKey) => byRuleKey.get(ruleKey))
-          .filter((rule): rule is AutoAssignRuleRow => Boolean(rule))
+          .filter((rule): rule is AutoAssignRuleRow => rule !== undefined && !forcedKeySet.has(rule.key))
       })
-      return [...nextForcedRules, ...nextGroupedRules]
+      const capturedKeys = new Set<AutoAssignRuleKey>([...forcedKeySet, ...nextGroupedRules.map((rule) => rule.key)])
+      const leftoverRules = current.filter((rule) => !capturedKeys.has(rule.key))
+      return [...nextForcedRules, ...nextGroupedRules, ...leftoverRules]
     }, direction === 'up' ? '制約グループの優先順位を上げました。' : '制約グループの優先順位を下げました。')
   }
 
@@ -723,6 +787,19 @@ export function AutoAssignRuleScreen({
         </div>
       ) : null}
       {!options?.hideDescription ? <p className="auto-assign-rule-description">{rule.description}</p> : null}
+      {getAllowedRuleCategories(rule.key).length > 1 ? (
+        <div className="auto-assign-rule-category-row" data-testid={`auto-assign-rule-category-row-${rule.key}`}>
+          <span className="auto-assign-rule-summary-segment">区分:</span>
+          <select
+            value={resolveRuleCategory(rule)}
+            onChange={(event) => setRuleCategory(rule.key, event.target.value as AutoAssignRuleCategory)}
+            data-testid={`auto-assign-rule-category-select-${rule.key}`}
+          >
+            <option value="constraint">制約事項</option>
+            <option value="priority">優先事項</option>
+          </select>
+        </div>
+      ) : null}
       {rule.key === 'forbidFirstPeriod' ? (
         <div className="auto-assign-rule-period-toggles" data-testid="auto-assign-forbidden-periods">
           <span className="auto-assign-rule-summary-segment">禁止する時限:</span>
@@ -738,6 +815,33 @@ export function AutoAssignRuleScreen({
               >{period}限</button>
             )
           })}
+        </div>
+      ) : null}
+      {rule.key === 'preferLateAfternoon' ? (
+        <div className="auto-assign-rule-period-order" data-testid="auto-assign-period-priority-order">
+          <span className="auto-assign-rule-summary-segment">優先する時限の順番:</span>
+          <ol className="auto-assign-period-order-list">
+            {resolvePeriodPriorityOrder(rule).map((period, index, order) => (
+              <li key={period} className="auto-assign-period-order-item" data-testid={`auto-assign-period-order-item-${period}`}>
+                <span className="auto-assign-period-order-rank">{index + 1}</span>
+                <span className="auto-assign-period-order-label">{period}限</span>
+                <button
+                  type="button"
+                  className="secondary-button slim"
+                  onClick={() => movePeriodPriority(rule.key, period, 'up')}
+                  disabled={index === 0}
+                  data-testid={`auto-assign-period-order-up-${period}`}
+                >上へ</button>
+                <button
+                  type="button"
+                  className="secondary-button slim"
+                  onClick={() => movePeriodPriority(rule.key, period, 'down')}
+                  disabled={index === order.length - 1}
+                  data-testid={`auto-assign-period-order-down-${period}`}
+                >下へ</button>
+              </li>
+            ))}
+          </ol>
         </div>
       ) : null}
       <div className="auto-assign-rule-summary" data-testid={`auto-assign-rule-summary-${rule.key}`}>

--- a/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
+++ b/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
@@ -2,9 +2,11 @@ import { useMemo, useState, type Dispatch, type SetStateAction } from 'react'
 import { AppMenu } from '../navigation/AppMenu'
 import { compareStudentsByCurrentGradeThenName, formatStudentSelectionLabel, getReferenceDateKey, getTeacherDisplayName, isActiveOnDate, resolveTeacherRosterStatus, type StudentRow, type TeacherRow } from '../basic-data/basicDataModel'
 import {
+  autoAssignPeriodOptions,
   autoAssignRuleDefinitions,
   createAutoAssignTargetId,
   listAutoAssignTargetGrades,
+  resolveForbiddenPeriods,
   resolveStudentGradeLabel,
   type AutoAssignRuleKey,
   type AutoAssignRuleRow,
@@ -221,6 +223,7 @@ export function buildAutoAssignWorkbook(
     ルールキー: rule.key,
     ルール名: rule.label,
     分類: forcedRuleKeys.has(rule.key) ? '制約事項' : '優先事項',
+    禁止時限: rule.key === 'forbidFirstPeriod' ? resolveForbiddenPeriods(rule).join(',') : '',
     対象: serializeAutoAssignTargets(rule.targets, studentNameById),
     対象外: serializeAutoAssignTargets(rule.excludeTargets, studentNameById),
   }))), 'ルール')
@@ -267,6 +270,10 @@ export function parseAutoAssignWorkbook(
           const definition = autoAssignRuleDefinitions.find((entry) => entry.key === key)
           if (!definition) return null
 
+          const forbiddenPeriods = key === 'forbidFirstPeriod'
+            ? resolveForbiddenPeriods({ forbiddenPeriods: normalizeText(row['禁止時限']).split(/[,、\s]+/).map((value) => Number(value)).filter((value) => Number.isFinite(value)) })
+            : undefined
+
           return {
             order: Number(row['並び順']) || index + 1,
             rule: {
@@ -274,6 +281,7 @@ export function parseAutoAssignWorkbook(
               targets: parseAutoAssignTargets(row['対象'], studentIdByName),
               excludeTargets: parseAutoAssignTargets(row['対象外'], studentIdByName),
               priorityScore: 3,
+              ...(forbiddenPeriods ? { forbiddenPeriods } : {}),
               includeStudentIds: [],
               excludeStudentIds: [],
               updatedAt: timestamp,
@@ -564,6 +572,18 @@ export function AutoAssignRuleScreen({
     updateRules((current) => current.map((rule) => rule.key === ruleKey ? { ...rule, excludeTargets: [] } : rule), '対象外をクリアしました。')
   }
 
+  // ⑧TODO3: 指定時限禁止の禁止時限トグル。最低1つは残す（空にしない）。
+  const toggleForbiddenPeriod = (ruleKey: AutoAssignRuleKey, period: number) => {
+    updateRules((current) => current.map((rule) => {
+      if (rule.key !== ruleKey) return rule
+      const currentPeriods = resolveForbiddenPeriods(rule)
+      const nextPeriods = currentPeriods.includes(period)
+        ? currentPeriods.filter((value) => value !== period)
+        : [...currentPeriods, period].sort((left, right) => left - right)
+      return { ...rule, forbiddenPeriods: nextPeriods.length > 0 ? nextPeriods : currentPeriods }
+    }), '指定時限禁止の時限を更新しました。')
+  }
+
   const moveRuleGroup = (groupKey: RuleGroupKey, direction: 'up' | 'down') => {
     const currentIndex = orderedRuleGroups.findIndex((group) => group.key === groupKey)
     const targetIndex = direction === 'up' ? currentIndex - 1 : currentIndex + 1
@@ -703,6 +723,23 @@ export function AutoAssignRuleScreen({
         </div>
       ) : null}
       {!options?.hideDescription ? <p className="auto-assign-rule-description">{rule.description}</p> : null}
+      {rule.key === 'forbidFirstPeriod' ? (
+        <div className="auto-assign-rule-period-toggles" data-testid="auto-assign-forbidden-periods">
+          <span className="auto-assign-rule-summary-segment">禁止する時限:</span>
+          {autoAssignPeriodOptions.map((period) => {
+            const active = resolveForbiddenPeriods(rule).includes(period)
+            return (
+              <button
+                key={period}
+                type="button"
+                className={`student-type-button compact${active ? ' active' : ''}`}
+                onClick={() => toggleForbiddenPeriod(rule.key, period)}
+                data-testid={`auto-assign-forbidden-period-${period}`}
+              >{period}限</button>
+            )
+          })}
+        </div>
+      ) : null}
       <div className="auto-assign-rule-summary" data-testid={`auto-assign-rule-summary-${rule.key}`}>
         <span className="auto-assign-rule-summary-segment" data-testid={`auto-assign-rule-targets-${rule.key}`} title={rule.targets.map((target) => describeTargetTooltip(target)).join('\n\n')}>
           ＋対象: {summarizeTargets(rule.targets, 'なし')}

--- a/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
+++ b/src/components/auto-assign-rules/AutoAssignRuleScreen.tsx
@@ -11,7 +11,7 @@ import {
   type AutoAssignTarget,
   type AutoAssignTargetGrade,
 } from './autoAssignRuleModel'
-import { createPairConstraintId, type PairConstraintRow } from '../../types/pairConstraint'
+import { createPairConstraintId, resolvePairConstraintCategory, type PairConstraintCategory, type PairConstraintRow } from '../../types/pairConstraint'
 
 type AutoAssignRuleScreenProps = {
   rules: AutoAssignRuleRow[]
@@ -103,6 +103,7 @@ function createEmptyPairConstraintDraft(): PairConstraintRow {
     personBType: 'student',
     personBId: '',
     type: 'incompatible',
+    category: 'constraint',
   }
 }
 
@@ -230,6 +231,7 @@ export function buildAutoAssignWorkbook(
     人物B種別: row.personBType === 'teacher' ? '講師' : '生徒',
     人物B: row.personBType === 'teacher' ? teacherNameById[row.personBId] ?? '' : studentNameById[row.personBId] ?? '',
     種別: '組み合わせ不可',
+    区分: resolvePairConstraintCategory(row) === 'priority' ? '優先事項' : '制約事項',
   }))), 'ペア制約')
 
   xlsx.utils.book_append_sheet(workbook, createWorkbookSheet(xlsx, [
@@ -314,6 +316,7 @@ export function parseAutoAssignWorkbook(
             personBType,
             personBId: personBType === 'teacher' ? teacherIdByName.get(normalizeText(row['人物B'])) ?? '' : studentIdByName.get(normalizeText(row['人物B'])) ?? '',
             type: 'incompatible' as const,
+            category: (normalizeText(row['区分']) === '優先事項' ? 'priority' : 'constraint') as PairConstraintCategory,
           }
         })
         .filter((row) => row.personAId && row.personBId)
@@ -748,6 +751,10 @@ export function AutoAssignRuleScreen({
           <option value="">人物Bを選択</option>
           {(pairConstraintDraft.personBType === 'teacher' ? visibleTeachers : visibleStudents).map((person) => <option key={person.id} value={person.id}>{pairConstraintDraft.personBType === 'teacher' ? teacherNameById[person.id] : studentNameById[person.id]}</option>)}
         </select>
+        <select value={pairConstraintDraft.category ?? 'constraint'} onChange={(event) => setPairConstraintDraft((current) => ({ ...current, category: event.target.value as PairConstraintCategory }))} data-testid="auto-assign-pair-draft-category">
+          <option value="constraint">制約事項</option>
+          <option value="priority">優先事項</option>
+        </select>
         <button className="primary-button" type="button" onClick={addPairConstraint} data-testid="auto-assign-pair-save-button">保存</button>
       </div>
       <table className="basic-data-table" data-testid="auto-assign-pair-constraints-table">
@@ -757,6 +764,7 @@ export function AutoAssignRuleScreen({
             <th></th>
             <th>人物B</th>
             <th>種別</th>
+            <th>区分</th>
             <th>操作</th>
           </tr>
         </thead>
@@ -790,13 +798,19 @@ export function AutoAssignRuleScreen({
               </td>
               <td><span className="status-chip secondary">組み合わせ不可</span></td>
               <td>
+                <select value={resolvePairConstraintCategory(row)} onChange={(event) => updatePairConstraint(row.id, { category: event.target.value as PairConstraintCategory })} data-testid={`auto-assign-pair-category-${row.id}`}>
+                  <option value="constraint">制約事項</option>
+                  <option value="priority">優先事項</option>
+                </select>
+              </td>
+              <td>
                 <div className="basic-data-row-actions">
                   <button className="secondary-button slim" type="button" onClick={() => removePairConstraint(row.id)} data-testid={`auto-assign-pair-remove-${row.id}`}>削除</button>
                 </div>
               </td>
             </tr>
           ))}
-          {pairConstraints.length === 0 ? <tr><td colSpan={5} className="basic-data-empty-row">ペア制約はまだありません。</td></tr> : null}
+          {pairConstraints.length === 0 ? <tr><td colSpan={6} className="basic-data-empty-row">ペア制約はまだありません。</td></tr> : null}
         </tbody>
       </table>
       <div className="auto-assign-pair-list" data-testid="auto-assign-pair-summary-list">

--- a/src/components/auto-assign-rules/autoAssignRuleModel.test.ts
+++ b/src/components/auto-assign-rules/autoAssignRuleModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { resolveForbiddenPeriods, resolveReferenceSchoolYear, resolveStudentGradeLabel } from './autoAssignRuleModel'
+import { getAllowedRuleCategories, getDefaultRuleCategory, resolveForbiddenPeriods, resolvePeriodPriorityOrder, resolveReferenceSchoolYear, resolveRuleCategory, resolveStudentGradeLabel } from './autoAssignRuleModel'
 
 // spec-auto-assign-rules ⑧TODO3: 指定時限禁止。未設定=[1]、1〜5のみ・昇順ユニーク。
 describe('resolveForbiddenPeriods', () => {
@@ -13,6 +13,54 @@ describe('resolveForbiddenPeriods', () => {
     expect(resolveForbiddenPeriods({ forbiddenPeriods: [3, 1, 3] })).toEqual([1, 3])
     expect(resolveForbiddenPeriods({ forbiddenPeriods: [5, 2, 9, 0] })).toEqual([2, 5])
     expect(resolveForbiddenPeriods({ forbiddenPeriods: [7, 8] })).toEqual([1])
+  })
+})
+
+// spec-auto-assign-rules ⑧TODO2: 時限優先スライダー。未設定=[5,4,3,2,1]、欠けは既定順で補完し常に1〜5全時限。
+describe('resolvePeriodPriorityOrder', () => {
+  it('defaults to [5,4,3,2,1] when unset/invalid (旧3,4,5限優先)', () => {
+    expect(resolvePeriodPriorityOrder(undefined)).toEqual([5, 4, 3, 2, 1])
+    expect(resolvePeriodPriorityOrder({ periodPriorityOrder: undefined })).toEqual([5, 4, 3, 2, 1])
+    expect(resolvePeriodPriorityOrder({ periodPriorityOrder: [] })).toEqual([5, 4, 3, 2, 1])
+  })
+
+  it('keeps the given order and appends missing periods in default order', () => {
+    expect(resolvePeriodPriorityOrder({ periodPriorityOrder: [2, 3] })).toEqual([2, 3, 5, 4, 1])
+    expect(resolvePeriodPriorityOrder({ periodPriorityOrder: [1, 2, 3, 4, 5] })).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('drops out-of-range and duplicate periods', () => {
+    expect(resolvePeriodPriorityOrder({ periodPriorityOrder: [3, 3, 9, 0, 2] })).toEqual([3, 2, 5, 4, 1])
+  })
+})
+
+// spec-auto-assign-rules ⑧TODO1: 区分許可リスト。制約可=コマ数上限/指定時限禁止/科目対応講師のみ/通常講師のみ。
+describe('auto-assign rule category allow-list', () => {
+  it('allows constraint only for hard-capable rules; others are priority-only', () => {
+    expect(getAllowedRuleCategories('forbidFirstPeriod')).toEqual(['constraint', 'priority'])
+    expect(getAllowedRuleCategories('maxTwoLessons')).toEqual(['constraint', 'priority'])
+    expect(getAllowedRuleCategories('subjectCapableTeachersOnly')).toEqual(['constraint', 'priority'])
+    expect(getAllowedRuleCategories('regularTeachersOnly')).toEqual(['constraint', 'priority'])
+    expect(getAllowedRuleCategories('preferDateConcentration')).toEqual(['priority'])
+    expect(getAllowedRuleCategories('preferLateAfternoon')).toEqual(['priority'])
+    expect(getAllowedRuleCategories('preferTwoStudentsPerTeacher')).toEqual(['priority'])
+  })
+
+  it('keeps current defaults: 3 forced rules constraint, lesson limits priority', () => {
+    expect(getDefaultRuleCategory('forbidFirstPeriod')).toBe('constraint')
+    expect(getDefaultRuleCategory('subjectCapableTeachersOnly')).toBe('constraint')
+    expect(getDefaultRuleCategory('regularTeachersOnly')).toBe('constraint')
+    expect(getDefaultRuleCategory('maxOneLesson')).toBe('priority')
+    expect(getDefaultRuleCategory('preferDateConcentration')).toBe('priority')
+  })
+
+  it('resolves to set category when allowed, else falls back to default', () => {
+    expect(resolveRuleCategory({ key: 'maxOneLesson', category: 'constraint' })).toBe('constraint')
+    expect(resolveRuleCategory({ key: 'maxOneLesson', category: undefined })).toBe('priority')
+    // 優先専用ルールに constraint を入れても既定(priority)へ丸める
+    expect(resolveRuleCategory({ key: 'preferDateConcentration', category: 'constraint' })).toBe('priority')
+    // 設定なしは既定
+    expect(resolveRuleCategory({ key: 'forbidFirstPeriod', category: undefined })).toBe('constraint')
   })
 })
 

--- a/src/components/auto-assign-rules/autoAssignRuleModel.test.ts
+++ b/src/components/auto-assign-rules/autoAssignRuleModel.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { resolveReferenceSchoolYear, resolveStudentGradeLabel } from './autoAssignRuleModel'
+import { resolveForbiddenPeriods, resolveReferenceSchoolYear, resolveStudentGradeLabel } from './autoAssignRuleModel'
+
+// spec-auto-assign-rules ⑧TODO3: 指定時限禁止。未設定=[1]、1〜5のみ・昇順ユニーク。
+describe('resolveForbiddenPeriods', () => {
+  it('defaults to [1] when unset/empty (旧1限禁止)', () => {
+    expect(resolveForbiddenPeriods(undefined)).toEqual([1])
+    expect(resolveForbiddenPeriods({ forbiddenPeriods: [] })).toEqual([1])
+    expect(resolveForbiddenPeriods({ forbiddenPeriods: undefined })).toEqual([1])
+  })
+
+  it('normalizes to sorted unique 1-5 and drops out-of-range', () => {
+    expect(resolveForbiddenPeriods({ forbiddenPeriods: [3, 1, 3] })).toEqual([1, 3])
+    expect(resolveForbiddenPeriods({ forbiddenPeriods: [5, 2, 9, 0] })).toEqual([2, 5])
+    expect(resolveForbiddenPeriods({ forbiddenPeriods: [7, 8] })).toEqual([1])
+  })
+})
 
 describe('autoAssignRuleModel grade resolution', () => {
   it('switches school year on April 1', () => {

--- a/src/components/auto-assign-rules/autoAssignRuleModel.ts
+++ b/src/components/auto-assign-rules/autoAssignRuleModel.ts
@@ -48,7 +48,22 @@ export type AutoAssignRuleRow = {
   priorityScore: number
   includeStudentIds?: string[]
   excludeStudentIds?: string[]
+  // spec-auto-assign-rules ⑧TODO3: 指定時限禁止（forbidFirstPeriod を一般化）。禁止する時限(1〜5)。
+  // 未設定は [1]（旧「1限禁止」）として扱う。
+  forbiddenPeriods?: number[]
   updatedAt: string
+}
+
+// 自動割振で扱う時限の範囲（1〜5限）。
+export const autoAssignPeriodOptions = [1, 2, 3, 4, 5] as const
+
+// 指定時限禁止の禁止時限を解決。未設定/空は既定 [1]（旧1限禁止）。1〜5のみ・昇順ユニーク。
+export function resolveForbiddenPeriods(rule: Pick<AutoAssignRuleRow, 'forbiddenPeriods'> | null | undefined): number[] {
+  const raw = rule?.forbiddenPeriods
+  if (!Array.isArray(raw) || raw.length === 0) return [1]
+  const normalized = Array.from(new Set(raw.filter((period) => autoAssignPeriodOptions.includes(period as (typeof autoAssignPeriodOptions)[number]))))
+    .sort((left, right) => left - right)
+  return normalized.length > 0 ? normalized : [1]
 }
 
 export const autoAssignRuleDefinitions: Array<Pick<AutoAssignRuleRow, 'key' | 'label' | 'description'>> = [
@@ -124,8 +139,8 @@ export const autoAssignRuleDefinitions: Array<Pick<AutoAssignRuleRow, 'key' | 'l
   },
   {
     key: 'forbidFirstPeriod',
-    label: '1限禁止',
-    description: '対象者を1 限に配置しないよう制限します。',
+    label: '指定時限禁止',
+    description: '対象者を、指定した時限（既定は1限）に配置しないよう制限します。',
   },
 ]
 

--- a/src/components/auto-assign-rules/autoAssignRuleModel.ts
+++ b/src/components/auto-assign-rules/autoAssignRuleModel.ts
@@ -14,6 +14,8 @@ export type AutoAssignRuleKey =
   | 'subjectCapableTeachersOnly'
   | 'regularTeachersOnly'
   | 'preferLateAfternoon'
+  // ⑧TODO2 で「時限優先」1ルール(preferLateAfternoon + periodPriorityOrder)へ統合済。
+  // 旧スナップショット互換のため型は残すが、定義/UI/アルゴリズムでは使わない（対象なし運用）。
   | 'preferSecondPeriod'
   | 'preferFifthPeriod'
   | 'forbidFirstPeriod'
@@ -32,6 +34,43 @@ export type AutoAssignTargetGrade =
   | '高2'
   | '高3'
 
+// spec-auto-assign-rules ⑧TODO1: 区分（優先事項／制約事項）。絶対事項はアプリ固定で別枠。
+export type AutoAssignRuleCategory = 'priority' | 'constraint'
+
+// 制約事項にも選べるルール（ハードとして効きうる）。それ以外は優先事項のみ。
+const constraintCapableRuleKeys = new Set<AutoAssignRuleKey>([
+  'maxOneLesson',
+  'maxTwoLessons',
+  'maxThreeLessons',
+  'subjectCapableTeachersOnly',
+  'regularTeachersOnly',
+  'forbidFirstPeriod',
+])
+// 既定で制約事項として扱うルール（現状の forcedRuleKeys を踏襲）。
+const defaultConstraintRuleKeys = new Set<AutoAssignRuleKey>([
+  'subjectCapableTeachersOnly',
+  'regularTeachersOnly',
+  'forbidFirstPeriod',
+])
+
+// ルールごとに選べる区分（許可リスト）。成立しない組合せ（優先専用ルールを制約に）を作れないようにする。
+export function getAllowedRuleCategories(key: AutoAssignRuleKey): AutoAssignRuleCategory[] {
+  return constraintCapableRuleKeys.has(key) ? ['constraint', 'priority'] : ['priority']
+}
+
+// ルールの既定区分。
+export function getDefaultRuleCategory(key: AutoAssignRuleKey): AutoAssignRuleCategory {
+  return defaultConstraintRuleKeys.has(key) ? 'constraint' : 'priority'
+}
+
+// ルールの区分を解決。未設定/許可外は既定区分に丸める。
+export function resolveRuleCategory(rule: Pick<AutoAssignRuleRow, 'key' | 'category'> | null | undefined): AutoAssignRuleCategory {
+  if (!rule) return 'priority'
+  const allowed = getAllowedRuleCategories(rule.key)
+  if (rule.category && allowed.includes(rule.category)) return rule.category
+  return getDefaultRuleCategory(rule.key)
+}
+
 export type AutoAssignTargetOrigin = 'manual' | 'group-conflict'
 
 export type AutoAssignTarget =
@@ -46,11 +85,16 @@ export type AutoAssignRuleRow = {
   targets: AutoAssignTarget[]
   excludeTargets: AutoAssignTarget[]
   priorityScore: number
+  // spec-auto-assign-rules ⑧TODO1: 区分（優先事項／制約事項）。未設定は getDefaultRuleCategory で補完。
+  category?: AutoAssignRuleCategory
   includeStudentIds?: string[]
   excludeStudentIds?: string[]
   // spec-auto-assign-rules ⑧TODO3: 指定時限禁止（forbidFirstPeriod を一般化）。禁止する時限(1〜5)。
   // 未設定は [1]（旧「1限禁止」）として扱う。
   forbiddenPeriods?: number[]
+  // spec-auto-assign-rules ⑧TODO2: 時限優先（preferLateAfternoon を一般化）。優先する時限の並び順。
+  // index0 が最優先。未設定は [5,4,3,2,1]（旧「3,4,5限優先」）として扱う。
+  periodPriorityOrder?: number[]
   updatedAt: string
 }
 
@@ -64,6 +108,25 @@ export function resolveForbiddenPeriods(rule: Pick<AutoAssignRuleRow, 'forbidden
   const normalized = Array.from(new Set(raw.filter((period) => autoAssignPeriodOptions.includes(period as (typeof autoAssignPeriodOptions)[number]))))
     .sort((left, right) => left - right)
   return normalized.length > 0 ? normalized : [1]
+}
+
+// 時限優先のスライダー順を解決。index0 が最優先。未設定/不正は既定 [5,4,3,2,1]（旧「3,4,5限優先」）。
+// 与えられた並びを尊重しつつ、欠けている時限を既定順で末尾に補い、常に 1〜5 の全時限を含む並びに正規化する。
+export function resolvePeriodPriorityOrder(rule: Pick<AutoAssignRuleRow, 'periodPriorityOrder'> | null | undefined): number[] {
+  const fallback = [5, 4, 3, 2, 1]
+  const raw = rule?.periodPriorityOrder
+  const ordered: number[] = []
+  if (Array.isArray(raw)) {
+    for (const period of raw) {
+      if (autoAssignPeriodOptions.includes(period as (typeof autoAssignPeriodOptions)[number]) && !ordered.includes(period)) {
+        ordered.push(period)
+      }
+    }
+  }
+  for (const period of fallback) {
+    if (!ordered.includes(period)) ordered.push(period)
+  }
+  return ordered
 }
 
 export const autoAssignRuleDefinitions: Array<Pick<AutoAssignRuleRow, 'key' | 'label' | 'description'>> = [
@@ -124,18 +187,8 @@ export const autoAssignRuleDefinitions: Array<Pick<AutoAssignRuleRow, 'key' | 'l
   },
   {
     key: 'preferLateAfternoon',
-    label: '3,4,5限優先',
-    description: '3 限から 5 限を先に使う優先順です。',
-  },
-  {
-    key: 'preferSecondPeriod',
-    label: '2限寄り(2＞3＞4＞5限の優先順位)',
-    description: '2 限から順に近いコマを優先します。',
-  },
-  {
-    key: 'preferFifthPeriod',
-    label: '5限寄り(5＞4＞3＞2限の優先順位)',
-    description: '5 限から順に近いコマを優先します。',
+    label: '時限優先',
+    description: '優先する時限の順番を 1〜5 限で並べ替えて、上にある時限から先に使うよう優先します。',
   },
   {
     key: 'forbidFirstPeriod',
@@ -151,6 +204,7 @@ export const initialAutoAssignRules: AutoAssignRuleRow[] = autoAssignRuleDefinit
   targets: [],
   excludeTargets: [],
   priorityScore: 3,
+  category: getDefaultRuleCategory(definition.key),
   includeStudentIds: [],
   excludeStudentIds: [],
   updatedAt: '',

--- a/src/components/basic-data/BasicDataScreen.tsx
+++ b/src/components/basic-data/BasicDataScreen.tsx
@@ -22,7 +22,6 @@ import {
 } from './basicDataModel'
 import {
   normalizeRegularLessonNote,
-  resolveOperationalSchoolYear,
 } from './regularLessonModel'
 import { normalizeRegularLessonTemplate, parseRegularLessonTemplateWorkbook } from '../regular-template/regularLessonTemplate'
 import { AppMenu } from '../navigation/AppMenu'
@@ -150,12 +149,9 @@ const dayOptions = [
 ]
 
 export const initialManagers: ManagerRow[] = []
-export const initialGroupLessons: GroupLessonRow[] = [
-  { id: 'g001', schoolYear: resolveOperationalSchoolYear(new Date()), teacherId: 't002', subject: '英', studentIds: ['s002', 's003'], dayOfWeek: 3, slotLabel: '2限' },
-  { id: 'g002', schoolYear: resolveOperationalSchoolYear(new Date()) - 1, teacherId: 't001', subject: '算', studentIds: ['s001'], dayOfWeek: 1, slotLabel: '1限' },
-  { id: 'g003', schoolYear: resolveOperationalSchoolYear(new Date()), teacherId: 't004', subject: '国', studentIds: ['s013', 's025'], dayOfWeek: 5, slotLabel: '3限' },
-  { id: 'g004', schoolYear: resolveOperationalSchoolYear(new Date()), teacherId: 't006', subject: '理', studentIds: ['s014', 's026'], dayOfWeek: 4, slotLabel: '4限' },
-]
+// spec-auto-assign-rules §G / ⑧TODO4: グループ授業(班)は編集UIが無く画面不可視。
+// サンプル種データは空にする（型・スナップショット配管は残す＝2026-06-09 オーナー判断）。
+export const initialGroupLessons: GroupLessonRow[] = []
 
 type ManagedIdKind = 'manager' | 'teacher' | 'student' | 'regular' | 'group'
 

--- a/src/components/schedule-board/ScheduleBoardScreen.tsx
+++ b/src/components/schedule-board/ScheduleBoardScreen.tsx
@@ -17,6 +17,7 @@ import type { DeskCell, DeskLesson, GradeLabel, LessonType, SlotCell, StudentEnt
 import type { ClassroomSettings, StudentScheduleRequest, TeacherAutoAssignRequest } from '../../App'
 import type { ManualLectureStockOrigin, PersistedBoardState, ScheduleCountAdjustmentEntry } from '../../types/appState'
 import type { PairConstraintRow } from '../../types/pairConstraint'
+import { resolvePairConstraintCategory } from '../../types/pairConstraint'
 import { exportBoardPdf, exportTemplateOverwriteReport } from '../../utils/pdf'
 import { generateQrSvg } from '../../utils/qrcode'
 import { buildCombinedRegularLessonsFromHistory, formatWeeklyScheduleTitle, openAllScheduleHtml, openStudentScheduleHtml, openTeacherScheduleHtml, syncStudentScheduleHtml, syncTeacherScheduleHtml } from '../../utils/scheduleHtml'
@@ -4042,22 +4043,29 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
     return teacherIds
   }
 
-  const isPairConstraintBlocked = (teacherId: string, primaryStudentId: string, otherStudent: StudentEntry | null) => {
+  // spec-auto-assign-rules §E / ⑧TODO5: ペア制約は 優先/制約 の2区分。
+  // 制約(既定)=赤の制約警告、優先=なるべく回避(スコアのみ)。複数一致時は強い方(制約)を採用。
+  const resolvePairConstraintSeverity = (teacherId: string, primaryStudentId: string, otherStudent: StudentEntry | null): 'none' | 'priority' | 'constraint' => {
     const otherStudentId = otherStudent?.managedStudentId ?? (otherStudent ? managedStudentByRegisteredName.get(otherStudent.name)?.id : undefined)
-    return pairConstraints.some((constraint) => {
-      if (constraint.type !== 'incompatible') return false
+    let severity: 'none' | 'priority' | 'constraint' = 'none'
+    for (const constraint of pairConstraints) {
+      if (constraint.type !== 'incompatible') continue
       const left = `${constraint.personAType}:${constraint.personAId}`
       const right = `${constraint.personBType}:${constraint.personBId}`
 
-      if ((left === `teacher:${teacherId}` && right === `student:${primaryStudentId}`) || (right === `teacher:${teacherId}` && left === `student:${primaryStudentId}`)) {
-        return true
-      }
+      const matchesTeacherStudent = (left === `teacher:${teacherId}` && right === `student:${primaryStudentId}`) || (right === `teacher:${teacherId}` && left === `student:${primaryStudentId}`)
+      const matchesStudentStudent = Boolean(otherStudentId) && ((left === `student:${primaryStudentId}` && right === `student:${otherStudentId}`) || (right === `student:${primaryStudentId}` && left === `student:${otherStudentId}`))
+      if (!matchesTeacherStudent && !matchesStudentStudent) continue
 
-      if (!otherStudentId) return false
-      return (left === `student:${primaryStudentId}` && right === `student:${otherStudentId}`)
-        || (right === `student:${primaryStudentId}` && left === `student:${otherStudentId}`)
-    })
+      if (resolvePairConstraintCategory(constraint) === 'constraint') return 'constraint'
+      severity = 'priority'
+    }
+    return severity
   }
+
+  const isPairConstraintBlocked = (teacherId: string, primaryStudentId: string, otherStudent: StudentEntry | null) => (
+    resolvePairConstraintSeverity(teacherId, primaryStudentId, otherStudent) !== 'none'
+  )
 
   const resolveSpecialSessionById = (sessionId?: string) => {
     if (!sessionId) return null
@@ -4891,8 +4899,13 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
               addWarning([currentLocationKey], '絶対事項: 出席可能コマのみ', true, true)
             }
 
-            if (teacher && isPairConstraintBlocked(teacher.id, managedStudent.id, pairedStudent)) {
-              addWarning([currentLocationKey], '制約: 組み合わせ不可', true, true)
+            if (teacher) {
+              const pairSeverity = resolvePairConstraintSeverity(teacher.id, managedStudent.id, pairedStudent)
+              if (pairSeverity === 'constraint') {
+                addWarning([currentLocationKey], '制約: 組み合わせ不可', true, true)
+              } else if (pairSeverity === 'priority') {
+                addWarning([currentLocationKey], '優先: 組み合わせ回避', true, false)
+              }
             }
           }
 

--- a/src/components/schedule-board/ScheduleBoardScreen.tsx
+++ b/src/components/schedule-board/ScheduleBoardScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { compareStudentsByCurrentGradeThenName, formatStudentSelectionLabel, getReferenceDateKey, getStudentDisplayName, getTeacherDisplayName, isActiveOnDate, resolveScheduledStatus, resolveTeacherRosterStatus, type GradeCeiling, type StudentRow, type TeacherRow } from '../basic-data/basicDataModel'
 import type { AutoAssignRuleKey, AutoAssignRuleRow, AutoAssignTarget } from '../auto-assign-rules/autoAssignRuleModel'
+import { resolveForbiddenPeriods } from '../auto-assign-rules/autoAssignRuleModel'
 import { isRegularLessonParticipantActiveOnDate, normalizeRegularLessonNote, resolveOperationalSchoolYear, type RegularLessonRow } from '../basic-data/regularLessonModel'
 import { buildRegularLessonsFromTemplate, buildRegularLessonTemplateWorkbook, buildTemplateBoardCells, convertTemplateCellsToTemplate, copyBoardCellsForTemplate, filterTemplateParticipantsForReferenceDate, listTemplateStartDatesFromWorkbook, normalizeRegularLessonTemplate, parseRegularLessonTemplateWorkbook, type RegularLessonTemplate } from '../regular-template/regularLessonTemplate'
 import type { SpecialSessionRow } from '../special-data/specialSessionModel'
@@ -3911,7 +3912,7 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
     const labelByRuleKey: Partial<Record<AutoAssignRuleKey, string>> = {
       subjectCapableTeachersOnly: '科目対応講師',
       regularTeachersOnly: '通常担当講師',
-      forbidFirstPeriod: '1限回避',
+      forbidFirstPeriod: '指定時限回避',
     }
     const labelByGroupKey: Record<LectureConstraintGroupKey, string> = {
       'day-spacing': '登校日集約/分散',
@@ -4339,6 +4340,7 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
       for (const cell of week) {
         const studentGradeOnDate = resolveSchoolGradeLabel(params.managedStudent.birthDate, parseDateKey(cell.dateKey))
         const forbidFirstPeriod = isAutoAssignRuleApplicable(autoAssignRuleByKey.get('forbidFirstPeriod'), params.managedStudent.id, studentGradeOnDate)
+        const forbiddenPeriods = resolveForbiddenPeriods(autoAssignRuleByKey.get('forbidFirstPeriod'))
         const subjectCapableTeachersOnly = isSubjectCapabilityConstraintApplicable(autoAssignRuleByKey, params.managedStudent.id, studentGradeOnDate)
         const regularTeachersOnly = isAutoAssignRuleApplicable(autoAssignRuleByKey.get('regularTeachersOnly'), params.managedStudent.id, studentGradeOnDate)
         if (!cell.isOpenDay) continue
@@ -4386,7 +4388,7 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
 
             if (!matchedItem) continue
 
-            const firstPeriodPreferred = !forbidFirstPeriod || cell.slotNumber !== 1
+            const firstPeriodPreferred = !forbidFirstPeriod || !forbiddenPeriods.includes(cell.slotNumber)
             const subjectCapablePreferred = !subjectCapableTeachersOnly || canTeacherHandleStudentSubject(teacher, matchedItem.subject, studentGradeOnDate)
             const regularTeacherPreferred = !regularTeachersOnly || regularTeacherIds.has(teacher.id)
             const scoreParts: AutoAssignScorePart[] = [
@@ -4847,8 +4849,8 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
           }
 
           if (managedStudent) {
-            if (isAutoAssignRuleApplicable(autoAssignRuleByKey.get('forbidFirstPeriod'), managedStudent.id, studentGradeOnDate) && cell.slotNumber === 1) {
-              addWarning([currentLocationKey], '制約事項: 1限禁止', true, true)
+            if (isAutoAssignRuleApplicable(autoAssignRuleByKey.get('forbidFirstPeriod'), managedStudent.id, studentGradeOnDate) && resolveForbiddenPeriods(autoAssignRuleByKey.get('forbidFirstPeriod')).includes(cell.slotNumber)) {
+              addWarning([currentLocationKey], '制約事項: 指定時限禁止', true, true)
             }
 
             const regularTeachersOnly = isAutoAssignRuleApplicable(autoAssignRuleByKey.get('regularTeachersOnly'), managedStudent.id, studentGradeOnDate)

--- a/src/components/schedule-board/ScheduleBoardScreen.tsx
+++ b/src/components/schedule-board/ScheduleBoardScreen.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { compareStudentsByCurrentGradeThenName, formatStudentSelectionLabel, getReferenceDateKey, getStudentDisplayName, getTeacherDisplayName, isActiveOnDate, resolveScheduledStatus, resolveTeacherRosterStatus, type GradeCeiling, type StudentRow, type TeacherRow } from '../basic-data/basicDataModel'
 import type { AutoAssignRuleKey, AutoAssignRuleRow, AutoAssignTarget } from '../auto-assign-rules/autoAssignRuleModel'
-import { resolveForbiddenPeriods } from '../auto-assign-rules/autoAssignRuleModel'
+import { resolveForbiddenPeriods, resolvePeriodPriorityOrder, resolveRuleCategory } from '../auto-assign-rules/autoAssignRuleModel'
 import { isRegularLessonParticipantActiveOnDate, normalizeRegularLessonNote, resolveOperationalSchoolYear, type RegularLessonRow } from '../basic-data/regularLessonModel'
 import { buildRegularLessonsFromTemplate, buildRegularLessonTemplateWorkbook, buildTemplateBoardCells, convertTemplateCellsToTemplate, copyBoardCellsForTemplate, filterTemplateParticipantsForReferenceDate, listTemplateStartDatesFromWorkbook, normalizeRegularLessonTemplate, parseRegularLessonTemplateWorkbook, type RegularLessonTemplate } from '../regular-template/regularLessonTemplate'
 import type { SpecialSessionRow } from '../special-data/specialSessionModel'
@@ -262,7 +262,7 @@ const lectureConstraintGroupDefinitions: Array<{ key: LectureConstraintGroupKey;
   { key: 'lesson-limit', orderKey: 'maxOneLesson', ruleKeys: ['maxOneLesson', 'maxTwoLessons', 'maxThreeLessons'] },
   { key: 'lesson-pattern', orderKey: 'allowTwoConsecutiveLessons', ruleKeys: ['allowTwoConsecutiveLessons', 'requireBreakBetweenLessons', 'connectRegularLessons'] },
   { key: 'day-spacing', orderKey: 'preferDateConcentration', ruleKeys: ['preferDateConcentration', 'preferNextDayOrLater'] },
-  { key: 'time-preference', orderKey: 'preferLateAfternoon', ruleKeys: ['preferLateAfternoon', 'preferSecondPeriod', 'preferFifthPeriod'] },
+  { key: 'time-preference', orderKey: 'preferLateAfternoon', ruleKeys: ['preferLateAfternoon'] },
 ]
 const gradeCeilingOrder: Record<GradeCeiling, number> = { 小: 1, 中: 2, 高1: 3, 高2: 4, 高3: 5 }
 
@@ -4220,31 +4220,17 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
           })
           continue
         }
-        if (applicableRule.key === 'preferLateAfternoon') {
-          scoreParts.push({
-            label: '時限希望',
-            value: ({ 5: 5, 4: 4, 3: 3, 2: 2, 1: 0 } as Record<number, number>)[params.cell.slotNumber] ?? 0,
-            detail: '遅い時限を優先',
-            applicable: true,
-            satisfied: params.cell.slotNumber >= 3,
-          })
-        } else if (applicableRule.key === 'preferSecondPeriod') {
-          scoreParts.push({
-            label: '時限希望',
-            value: ({ 2: 5, 3: 4, 4: 3, 5: 2, 1: 0 } as Record<number, number>)[params.cell.slotNumber] ?? 0,
-            detail: '2限寄りを優先',
-            applicable: true,
-            satisfied: params.cell.slotNumber === 2,
-          })
-        } else {
-          scoreParts.push({
-            label: '時限希望',
-            value: ({ 5: 5, 4: 4, 3: 3, 2: 2, 1: 0 } as Record<number, number>)[params.cell.slotNumber] ?? 0,
-            detail: '5限寄りを優先',
-            applicable: true,
-            satisfied: params.cell.slotNumber === 5,
-          })
-        }
+        // ⑧TODO2: 時限優先スライダー。優先順 index0 を最高得点とし、順位が下がるほど減点する。
+        const periodOrder = resolvePeriodPriorityOrder(applicableRule)
+        const rankIndex = periodOrder.indexOf(params.cell.slotNumber)
+        const effectiveRank = rankIndex < 0 ? periodOrder.length : rankIndex
+        scoreParts.push({
+          label: '時限希望',
+          value: periodOrder.length - effectiveRank,
+          detail: `優先する時限の順番 ${periodOrder.map((period) => `${period}限`).join('＞')}`,
+          applicable: true,
+          satisfied: effectiveRank < 3,
+        })
         continue
       }
 
@@ -4845,18 +4831,19 @@ export function ScheduleBoardScreen({ classroomSettings, classroomName, classroo
           }
 
           if (teacher && managedStudent && isSubjectCapabilityConstraintApplicable(autoAssignRuleByKey, managedStudent.id, studentGradeOnDate) && !canTeacherHandleStudentSubject(teacher, student.subject, studentGradeOnDate)) {
-            addWarning([currentLocationKey], '制約事項: 科目対応講師のみ', true, true)
+            // ⑧TODO1: 区分（制約事項／優先事項）に応じてラベルを切り替える。
+            addWarning([currentLocationKey], `${resolveRuleCategory(autoAssignRuleByKey.get('subjectCapableTeachersOnly')) === 'constraint' ? '制約事項' : '優先事項'}: 科目対応講師のみ`, true, true)
           }
 
           if (managedStudent) {
             if (isAutoAssignRuleApplicable(autoAssignRuleByKey.get('forbidFirstPeriod'), managedStudent.id, studentGradeOnDate) && resolveForbiddenPeriods(autoAssignRuleByKey.get('forbidFirstPeriod')).includes(cell.slotNumber)) {
-              addWarning([currentLocationKey], '制約事項: 指定時限禁止', true, true)
+              addWarning([currentLocationKey], `${resolveRuleCategory(autoAssignRuleByKey.get('forbidFirstPeriod')) === 'constraint' ? '制約事項' : '優先事項'}: 指定時限禁止`, true, true)
             }
 
             const regularTeachersOnly = isAutoAssignRuleApplicable(autoAssignRuleByKey.get('regularTeachersOnly'), managedStudent.id, studentGradeOnDate)
             const regularTeacherIds = resolveRegularTeacherIdsForStudentOnDate(managedStudent.id, cell.dateKey)
             if (regularTeachersOnly && (!teacher || !regularTeacherIds.has(teacher.id))) {
-              addWarning([currentLocationKey], '制約事項: 通常講師のみ', true, true)
+              addWarning([currentLocationKey], `${resolveRuleCategory(autoAssignRuleByKey.get('regularTeachersOnly')) === 'constraint' ? '制約事項' : '優先事項'}: 通常講師のみ`, true, true)
             }
 
             const twoStudentsRuleApplied = isAutoAssignRuleApplicable(autoAssignRuleByKey.get('preferTwoStudentsPerTeacher'), managedStudent.id, studentGradeOnDate)

--- a/src/types/pairConstraint.test.ts
+++ b/src/types/pairConstraint.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePairConstraintCategory } from './pairConstraint'
+
+// spec-auto-assign-rules §E / ⑧TODO5: 既定=制約事項。旧データ(category未設定)も制約扱い。
+describe('resolvePairConstraintCategory', () => {
+  it('defaults to constraint when unset (backward compatible)', () => {
+    expect(resolvePairConstraintCategory(undefined)).toBe('constraint')
+    expect(resolvePairConstraintCategory(null)).toBe('constraint')
+    expect(resolvePairConstraintCategory({})).toBe('constraint')
+    expect(resolvePairConstraintCategory({ category: undefined })).toBe('constraint')
+  })
+
+  it('returns priority only when explicitly set', () => {
+    expect(resolvePairConstraintCategory({ category: 'priority' })).toBe('priority')
+    expect(resolvePairConstraintCategory({ category: 'constraint' })).toBe('constraint')
+  })
+})

--- a/src/types/pairConstraint.ts
+++ b/src/types/pairConstraint.ts
@@ -1,3 +1,6 @@
+// spec-auto-assign-rules §E / ⑧TODO5: ペア制約の区分は 優先/制約 の2区分（既定=制約事項）。
+export type PairConstraintCategory = 'priority' | 'constraint'
+
 export type PairConstraintRow = {
   id: string
   personAType: 'teacher' | 'student'
@@ -5,10 +8,17 @@ export type PairConstraintRow = {
   personBType: 'teacher' | 'student'
   personBId: string
   type: 'incompatible'
+  // 区分。未設定(旧データ)は既定の 'constraint'（必ず守る）として扱う。
+  category?: PairConstraintCategory
 }
 
 export const initialPairConstraints: PairConstraintRow[] = []
 
 export function createPairConstraintId() {
   return `constraint_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`
+}
+
+// 旧データ後方互換: category 未設定は 'constraint' を既定とする。
+export function resolvePairConstraintCategory(row: Pick<PairConstraintRow, 'category'> | null | undefined): PairConstraintCategory {
+  return row?.category === 'priority' ? 'priority' : 'constraint'
 }


### PR DESCRIPTION
## 概要
Phase6 ⑧自動割振ルールの実装一式。本PRで ⑧の TODO5/4/3/2/1 がすべて本番反映可能になります。

### このブランチの内容
- ✅ TODO5 ペア制約2区分（優先/制約）
- ✅ TODO4 groupLessons 種データ空
- ✅ TODO3 指定時限禁止スライダー（1〜5限トグル）
- ✅ **TODO2 時限優先スライダー**（3ルール統合→並べ替え式1ルール）
- ✅ **TODO1 区分許可リスト**（編集可能な category＋許可リスト、forcedRuleKeys 置換）

### 挙動・互換性
- **割振アルゴリズムはソフト維持**（区分=制約をハードフィルタ化しない＝本番の割振結果を変えない／オーナー確認済み）。
- 時限優先のルール未設定時の既定挙動は不変（[5,4,3,2,1]）。
- 旧「2限寄り/5限寄り」を明示設定していた教室は既定（遅い時限優先）へ戻る（スライダーで再設定）。

### 検証
- `npm run build` グリーン（tsc 型チェック含む）
- `npm run test:unit` **278件グリーン**（+6）、ゴールデンスナップショット破壊なし

詳細: `docs/spec-auto-assign-rules.md` 実装状況。

🤖 Generated with [Claude Code](https://claude.com/claude-code)