### PR TITLE
fix(生徒日程表): 通常生徒の managedStudentId 欠落で通常授業がカウントされない回帰を修正

### DIFF
--- a/src/components/schedule-board/ScheduleBoardScreen.test.ts
+++ b/src/components/schedule-board/ScheduleBoardScreen.test.ts
@@ -1195,6 +1195,85 @@ describe('ScheduleBoardScreen buildManagedScheduleCellsForRange', () => {
     expect(actualDesk?.teacherAssignmentTeacherId).toBe('teacher-ochiai')
   })
 
+  // 回帰防止(6793374 / commit 2dce7b4 で巻き戻り再発): 盤面の通常生徒スロットが managedStudentId を
+  // 欠いても、マージで管理データ(テンプレ)側の生徒IDを保持する。これを欠くと生徒日程表で本人に紐づかず
+  // 通常授業がカウントされない(同一生徒が複数の通常授業を持つと顕在化。実例: 井上陽斗の金曜英語)。
+  it('盤面の通常生徒が managedStudentId を欠いても管理データの生徒IDを保持する', () => {
+    const teachers = [{
+      ...initialTeachers[0]!,
+      id: 'teacher-ochiai',
+      name: 'Ochiai Taro',
+      displayName: 'Ochiai',
+      entryDate: '2026-04-01',
+      withdrawDate: '未定',
+    }]
+    const students = [{
+      ...initialStudents[0]!,
+      id: 'student-inoue',
+      name: 'Inoue Hana',
+      displayName: 'Inoue',
+      entryDate: '2026-04-01',
+      withdrawDate: '未定',
+    }]
+    const regularLessons = [{
+      id: 'regular-ochiai-inoue',
+      schoolYear: 2026,
+      teacherId: 'teacher-ochiai',
+      student1Id: 'student-inoue',
+      subject1: '英',
+      startDate: '2026-04-01',
+      endDate: '未定',
+      student2Id: '',
+      subject2: '',
+      student2StartDate: '',
+      student2EndDate: '',
+      nextStudent1Id: '',
+      nextSubject1: '',
+      nextStudent2Id: '',
+      nextSubject2: '',
+      dayOfWeek: 5,
+      slotNumber: 5,
+    }]
+    const rangeParams = {
+      range: { startDate: '2026-07-01', endDate: '2026-07-31', periodValue: '' },
+      fallbackStartDate: '2026-07-01',
+      fallbackEndDate: '2026-07-31',
+      classroomSettings,
+      teachers,
+      students,
+      regularLessons,
+      suppressedRegularLessonOccurrences: [],
+    }
+
+    const planned = buildManagedScheduleCellsForRange({ ...rangeParams, boardWeeks: [] })
+    const plannedTarget = planned.find((cell) => cell.dateKey === '2026-07-03' && cell.slotNumber === 5)
+    expect(plannedTarget?.desks.some((desk) => desk.lesson?.studentSlots.some((student) => student?.managedStudentId === 'student-inoue'))).toBe(true)
+
+    // 盤面側は managedStudentId を失い、名前のみで残っている状態を再現する。
+    const legacyBoardWeek = planned.map((cell) => cell.id === plannedTarget?.id
+      ? {
+          ...cell,
+          desks: cell.desks.map((desk) => desk.lesson?.studentSlots.some((student) => student?.managedStudentId === 'student-inoue')
+            ? {
+                ...desk,
+                lesson: {
+                  ...desk.lesson!,
+                  studentSlots: desk.lesson!.studentSlots.map((student) => student?.managedStudentId === 'student-inoue'
+                    ? { ...student, managedStudentId: undefined }
+                    : student) as [StudentEntry | null, StudentEntry | null],
+                },
+              }
+            : desk),
+        }
+      : cell)
+
+    const actual = buildScheduleCellsForRange({ ...rangeParams, boardWeeks: [legacyBoardWeek] })
+    const actualTarget = actual.find((cell) => cell.dateKey === '2026-07-03' && cell.slotNumber === 5)
+    const actualStudent = actualTarget?.desks.flatMap((desk) => desk.lesson?.studentSlots ?? []).find((student) => student?.subject === '英')
+
+    expect(actualStudent?.managedStudentId).toBe('student-inoue')
+  })
+
   it('keeps all remaining weekly student placements when a regular lesson ends mid-month with fewer than four active weeks left', () => {
     const cells = buildManagedScheduleCellsForRange({
       range: {

--- a/src/components/schedule-board/ScheduleBoardScreen.tsx
+++ b/src/components/schedule-board/ScheduleBoardScreen.tsx
@@ -1874,7 +1874,16 @@ function mergeManagedDeskLesson(currentLesson: DeskLesson, managedLesson: DeskLe
       || student.name === managedStudent.name
     )
     if (isSameManagedStudent) {
-      nextLesson.studentSlots[slotIndex] = { ...managedStudent, ...student }
+      // 盤面の通常生徒スロットが managedStudentId 等を欠く場合、テンプレ(managed)側の同一性を補完する。
+      // これを欠くと spread で managedStudentId が undefined 上書きされ、生徒日程表で本人に紐づかず
+      // 通常授業がカウントされない(同一生徒が複数の通常授業を持つと顕在化)。回帰防止: 6793374。
+      nextLesson.studentSlots[slotIndex] = {
+        ...managedStudent,
+        ...student,
+        id: student.id || managedStudent.id,
+        managedStudentId: student.managedStudentId ?? managedStudent.managedStudentId,
+        birthDate: student.birthDate ?? managedStudent.birthDate,
+      }
       return
     }
 


### PR DESCRIPTION
## 概要（本番バグ修正）
生徒日程表（盤面の個人別ビュー）で、盤面に存在する**通常授業が表示・カウントされない**回帰を修正。
実例: 開発用教室の井上陽斗の金曜5限（落合・英）が日程表に出ず、通常回数 英=0(6) になっていた。

## 原因
`mergeManagedDeskLesson`（盤面→日程表セルのマージ）で `{ ...managedStudent, ...student }` のみになっており、
盤面の通常生徒スロットが `managedStudentId` を欠く場合に **undefined で上書き**され、生徒に紐づかなくなる。
同一生徒が複数の通常授業を持つ（曜日/科目違い）と片方で顕在化。

過去に修正済み（commit `6793374` Preserve managed student identity in schedule merge）だったが、
commit `2dce7b4` のマージで**巻き戻っていた回帰**。

## 修正
`mergeManagedDeskLesson` の同一生徒マージで `id` / `managedStudentId` / `birthDate` をテンプレ(managed)側から補完し同一性を保持。

## 検証
- 回帰防止テスト追加（盤面スロットの managedStudentId を欠落させ、マージ後に保持されることを検証）。**修正なしで失敗・修正ありで通過**を確認。
- `npm run build` グリーン / `npm run test:unit` 279件グリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)