### PR TITLE
fix(生徒日程表): テンプレに無い盤面の通常授業が日程表で脱落するバグを修正

### DIFF
--- a/src/components/schedule-board/ScheduleBoardScreen.test.ts
+++ b/src/components/schedule-board/ScheduleBoardScreen.test.ts
@@ -4,7 +4,7 @@ import { createInitialRegularLessons } from '../basic-data/regularLessonModel'
 import type { ClassroomSettings } from '../../types/appState'
 import { buildLinkedLessonDestinationMap } from './lessonLinks'
 import type { DeskCell, SlotCell, StudentEntry, StudentStatusEntry } from './types'
-import { appendDeletedStudentScheduleCountAdjustment, appendHistoryEntry, applyClassroomAvailability, buildBoardStudentSelectionOptions, buildManagedScheduleCellsForRange, buildScheduleCellsForRange, buildTeacherSelectionOptions, buildTemplateStudentSelectionOptions, clampPopoverPosition, clearStudentStatusFromDesk, cloneWeek, cloneWeeks, cloneWeeksForActiveWeek, cloneWeeksForPublish, ensureWeeksCoverDateRange, filterTemplateOverwriteHolidayDates, findDuplicateStudentInCellByKey, MAX_HISTORY_DEPTH, normalizeLessonPlacement, packSortCellDesks, prepareStudentForMove, removeLecturePendingItemFromStockState, removeStudentFromDeskLesson } from './ScheduleBoardScreen'
+import { appendDeletedStudentScheduleCountAdjustment, appendHistoryEntry, applyClassroomAvailability, buildBoardStudentSelectionOptions, buildManagedScheduleCellsForRange, buildScheduleCellsForRange, buildTeacherSelectionOptions, buildTemplateStudentSelectionOptions, clampPopoverPosition, clearStudentStatusFromDesk, cloneWeek, cloneWeeks, cloneWeeksForActiveWeek, cloneWeeksForPublish, ensureWeeksCoverDateRange, filterTemplateOverwriteHolidayDates, findDuplicateStudentInCellByKey, MAX_HISTORY_DEPTH, normalizeLessonPlacement, overlayBoardWeeksOnScheduleCells, packSortCellDesks, prepareStudentForMove, removeLecturePendingItemFromStockState, removeStudentFromDeskLesson } from './ScheduleBoardScreen'
 import { buildRegularLessonsFromTemplate, type RegularLessonTemplate } from '../regular-template/regularLessonTemplate'
 import { buildMakeupStockEntries } from './makeupStock'
 
@@ -1876,6 +1876,36 @@ describe('ScheduleBoardScreen buildManagedScheduleCellsForRange', () => {
 
     expect(managedDesk?.lesson?.studentSlots[0]?.managedStudentId).toBe('s002')
     expect(managedDesk?.lesson?.studentSlots.some((student) => student?.managedStudentId === 's001')).toBe(false)
+  })
+
+  // 回帰防止: テンプレ(管理セル)に無い盤面の通常授業が、同deskIndexの別テンプレ授業(他の盤面デスクでID一致消費される)と
+  // 衝突して脱落し、生徒日程表に出ない／カウントされない不具合。実例: 夏期講習期間の井上陽斗の金曜英語。
+  // 「日程表=盤面の個人別ビュー」のため、テンプレ未反映の盤面通常授業は保持する。
+  it('盤面の通常授業がテンプレに無く同indexで別テンプレ授業と衝突しても保持する', () => {
+    const mkLesson = (id: string, students: Array<StudentEntry | null>) => ({ id, note: '管理データ反映', studentSlots: students as [StudentEntry | null, StudentEntry | null] })
+    const mkCell = (cellId: string, desks: any[]) => ({ id: cellId, dateKey: '2026-08-07', dayLabel: '', dateLabel: '', slotLabel: '5限', slotNumber: 5, isOpenDay: true, desks }) as unknown as SlotCell
+    const s001 = createStudentEntry('s001', '生徒一', '数')
+    const s002 = createStudentEntry('s002', '生徒二', '英') // テンプレに無い盤面通常授業
+    const s003 = createStudentEntry('s003', '生徒三', '国')
+
+    // テンプレ(管理セル): desk0=managed_a(s001), desk1=managed_c(s003)
+    const managedCell = mkCell('C1', [
+      { id: 'd0', teacher: 'TA', lesson: mkLesson('managed_a', [s001, null]) },
+      { id: 'd1', teacher: 'TC', lesson: mkLesson('managed_c', [s003, null]) },
+    ])
+    // 盤面: desk0=managed_a(s001), desk1=managed_b(s002・テンプレ未反映), desk2=managed_c(s003)
+    // 盤面desk1(s002)の index1 はテンプレの managed_c と衝突するが、managed_c は盤面desk2でID一致消費される。
+    const boardCell = mkCell('C1', [
+      { id: 'd0', teacher: 'TA', lesson: mkLesson('managed_a', [s001, null]) },
+      { id: 'd1b', teacher: 'TB', lesson: mkLesson('managed_b', [s002, null]) },
+      { id: 'd2', teacher: 'TC', lesson: mkLesson('managed_c', [s003, null]) },
+    ])
+
+    const [merged] = overlayBoardWeeksOnScheduleCells([managedCell], [[boardCell]], [])
+    const placedIds = (merged.desks || []).flatMap((d) => (d.lesson?.studentSlots || []).filter(Boolean).map((s) => s!.managedStudentId))
+    expect(placedIds).toContain('s002') // テンプレ未反映の盤面通常授業が保持される
+    expect(placedIds).toContain('s001')
+    expect(placedIds).toContain('s003')
   })
 
   it('preserves a makeup student in a desk whose managed lesson is fully suppressed', () => {

--- a/src/components/schedule-board/ScheduleBoardScreen.tsx
+++ b/src/components/schedule-board/ScheduleBoardScreen.tsx
@@ -2247,6 +2247,11 @@ function mergeManagedWeek(currentWeek: SlotCell[], managedWeek: SlotCell[], orig
         .filter((desk) => desk.lesson && isManagedLesson(desk.lesson))
         .map((desk) => [desk.lesson!.id, desk]),
     )
+    // テンプレ(管理セル)に存在する生徒の同一性キー集合。盤面の通常授業がテンプレに一切無い場合の保持判定に使う。
+    const managedStudentKeysInCell = new Set<string>()
+    originalManagedCell.desks.forEach((managedDesk) => managedDesk.lesson?.studentSlots.forEach((managedStudent) => {
+      if (managedStudent) managedStudentKeysInCell.add(managedStudent.managedStudentId ?? managedStudent.name)
+    }))
     const preservedLessonIds = new Set<string>()
 
     // Pre-compute which managed lesson IDs have direct ID matches from board desks
@@ -2318,7 +2323,19 @@ function mergeManagedWeek(currentWeek: SlotCell[], managedWeek: SlotCell[], orig
 
         const originalSameLessonWasSuppressed = originalManagedDesksByLessonId.has(lesson.id)
         const sameDeskManagedLesson = managedCell.desks[deskIndex]?.lesson
-        if (!originalSameLessonWasSuppressed && (!sameDeskManagedLesson || !isManagedLesson(sameDeskManagedLesson))) {
+        const sameDeskManagedLessonIsManaged = Boolean(sameDeskManagedLesson && isManagedLesson(sameDeskManagedLesson))
+        // 同deskIndex を占める管理授業が「別の盤面デスクで lessonId 一致により消費される」場合、
+        // それはこの盤面デスクの後継(再割当)ではなく、たまたま同indexに来た無関係なテンプレ授業。
+        // このとき、盤面の通常生徒がテンプレに一切存在しない＝テンプレ未反映の盤面通常授業なので保持する。
+        // 日程表=盤面の個人別ビューのため。これを欠くと夏期講習期間の井上陽斗の金曜英語のように、
+        // テンプレに無い通常授業が同indexの別テンプレ授業と衝突して脱落し、生徒日程表でカウントされない。
+        // ※ 通常授業の生徒が「別生徒へ再割当」されたケース(後継テンプレが同indexを占める)は従来どおり旧生徒を落とす。
+        const sameDeskManagedLessonConsumedElsewhere = sameDeskManagedLessonIsManaged && idMatchedManagedIds.has(sameDeskManagedLesson!.id)
+        const hasRegularStudentMissingFromManagedCell = lesson.studentSlots.some((boardStudent) =>
+          boardStudent && boardStudent.lessonType === 'regular' && !boardStudent.manualAdded
+          && !isReturnedToOriginalDate(boardStudent, cell.dateKey)
+          && !managedStudentKeysInCell.has(boardStudent.managedStudentId ?? boardStudent.name))
+        if (!originalSameLessonWasSuppressed && (!sameDeskManagedLessonIsManaged || (sameDeskManagedLessonConsumedElsewhere && hasRegularStudentMissingFromManagedCell))) {
           preservedLessonIds.add(lesson.id)
           return {
             ...desk,


### PR DESCRIPTION
## Summary
- `mergeManagedWeek` で、盤面の通常授業がテンプレに存在しない場合かつ同 deskIndex にテンプレの別授業が存在すると、盤面の授業が `lesson: undefined` に落とされていた
- 真因：テンプレの別授業が他の盤面デスクに id マッチ済み（`idMatchedManagedIds`）で「使用済み」な場合、盤面の通常授業は保持すべきだが、保持条件が不足していた
- 修正：`managedStudentKeysInCell`（テンプレセル内の全生徒キー）を追跡し、盤面の通常生徒がテンプレセル全体に存在せず、かつ同 index のテンプレ授業が他で消費済みの場合に盤面授業を保持
- 回帰防止テスト追加（修正なしで落ち・修正ありで通る）

## Test plan
- [x] `npm run test:unit` 280件グリーン（回帰なし）
- [x] 実データ（バックアップJSON）で 井上陽斗の夏期英語 0件 → 6件（7/24,7/31,8/7,8/14,8/21,8/28）復活を確認
- [x] 「別生徒への再割当」ケースは旧生徒を正しく落とすことを既存テストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)