### PR TITLE
fix(オプション欄): 登録チェックを生徒日程表の右列✓に即時反映(残課題②)

### DIFF
--- a/src/utils/scheduleHtml.test.ts
+++ b/src/utils/scheduleHtml.test.ts
@@ -718,6 +718,40 @@ describe('scheduleHtml buildExpectedRegularOccurrences', () => {
     vi.unstubAllGlobals()
   })
 
+  it('mirrors registered optionChecks onto DATA.students so the right column reflects locally', () => {
+    // 残課題②回帰防止: 登録ダイアログでチェックして保存しても、updateStudentCountLocally が
+    // DATA.specialSessions だけ更新して DATA.students[].optionChecks を更新しないと、右列✓は
+    // 表示中セッションの古い値のまま再描画され反映されない。生徒へのミラー更新が消えると再発する。
+    const write = vi.fn()
+    const popup = {
+      closed: false,
+      document: { open() {}, write, close() {} },
+      focus() {},
+      postMessage() {},
+    } as unknown as Window
+    vi.stubGlobal('window', {
+      open: () => popup,
+      setTimeout: (callback: () => void) => { callback(); return 0 },
+    })
+
+    openStudentScheduleHtml({
+      cells: [],
+      plannedCells: [],
+      students: [createStudent({ displayName: '山田' })],
+      regularLessons: [],
+      defaultStartDate: '2026-03-24',
+      defaultEndDate: '2026-03-24',
+      titleLabel: 'テスト',
+      classroomSettings: { closedWeekdays: [0], holidayDates: [], forceOpenDates: [] },
+      targetWindow: popup,
+    })
+    const studentHtml = write.mock.calls[0]?.[0] as string
+    // 登録時に渡された optionChecks を、表示中の生徒オブジェクトへもミラーする。
+    expect(studentHtml).toContain('optionCheckTargetStudent.optionChecks = optionChecks || {}')
+
+    vi.unstubAllGlobals()
+  })
+
   it('exposes the empty-format print button and builder only in the student view', () => {
     const write = vi.fn()
     const popup = {

--- a/src/utils/scheduleHtml.ts
+++ b/src/utils/scheduleHtml.ts
@@ -3419,6 +3419,14 @@ function createScheduleHtml(payload: SchedulePayload, viewType: 'student' | 'tea
             },
           };
         });
+        // オプション欄(開発用教室): 右列の✓は DATA.students[].optionChecks から描画される
+        // (buildStudentPayload が表示中セッションの studentInput.optionChecks を載せる)。
+        // セッション入力だけ更新しても render() は生徒オブジェクトの古い値を読むため反映されない。
+        // 登録ダイアログで渡されたチェックを生徒にもミラーして即時反映する(未指定=保全)。
+        if (optionChecks !== undefined) {
+          var optionCheckTargetStudent = (DATA.students || []).find(function(s) { return s.id === personId; });
+          if (optionCheckTargetStudent) optionCheckTargetStudent.optionChecks = optionChecks || {};
+        }
       }
 
       function updateTeacherUnavailableSlotsLocally(sessionId, personId, unavailableSlots) {


### PR DESCRIPTION
## 概要
生徒日程表の**登録ダイアログ**でオプションにチェックして保存しても、オプション欄の**右列✓が更新されない**不具合（引き継ぎ資料 残課題②）を修正。

## 原因
- 右列✓は `DATA.students[].optionChecks` を描画元にする（`buildStudentPayload` が表示中セッションの `studentInput.optionChecks` を載せる）。
- 登録保存時の `updateStudentCountLocally` は `DATA.specialSessions[].studentInputs[].optionChecks` だけを更新し、`DATA.students[].optionChecks` を更新しない。App 側ハンドラ `schedule-student-count-save` も popup を再同期しないため、`render()` は古い値を読み右列が変わらない。

## 修正
`updateStudentCountLocally` で、登録時に渡された `optionChecks` を表示中の生徒オブジェクト（`DATA.students[]`）へミラーして即時反映。未指定時（登録解除等）は保全し、QR提出値を消さない。

## テスト
- 回帰防止テスト追加（生徒へのミラー更新が消えると失敗）。
- `test:unit` **378 緑**、本番ビルド・型チェックOK、差分 42 insertions / 0 deletions。
- 開発用教室のみ有効（`studentScheduleOptionField` フラグ）。ホスティング側のみの変更＝関数デプロイ不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)