### PR TITLE
fix(オプション欄): 登録済み生徒でもQR提出のoptionChecks/集団参加を反映(消失防止)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { useClassroomTabLock } from './utils/useClassroomTabLock'
 import { useAppVersionMonitor } from './utils/useAppVersionMonitor'
 import { isDevelopmentClassroom } from './utils/developmentClassroom'
 import { isFeatureEnabledForClassroom } from './utils/featureRollout'
+import { reflectParentOwnedSubmissionFields } from './utils/submissionReflection'
 import { bumpMemCounter } from './utils/memoryDiagnostics'
 import { trimBoardWeeksForMemory } from './components/schedule-board/boardWeekTrim'
 import './App.css'
@@ -3680,6 +3681,10 @@ function AuthenticatedApp() {
 
       const newlyAppliedEntries: typeof activeEntries = []
 
+      // 登録済み生徒に対する保護者所有フィールド(optionChecks/groupClassParticipation)の反映が
+      // あったか。newlyAppliedEntries とは別管理にし、これがあれば state を更新する(下の return 参照)。
+      let reflectedParentFields = false
+
       setSpecialSessions((current) => {
         let updated = current
         for (const entry of activeEntries) {
@@ -3705,7 +3710,23 @@ function AuthenticatedApp() {
               }
             } else {
               const existing = session.studentInputs[entry.personId]
-              if (existing?.countSubmitted) return session
+              if (existing?.countSubmitted) {
+                // 登録済みでも、保護者がQRで決める optionChecks / groupClassParticipation は
+                // 常に最新の提出値を反映する(回数・配置は再実行しない)。反映しないと室長ローカルが
+                // 古いまま手動保存され、Cloud Function がスナップショットへ統合した正しい提出値を
+                // 上書きして消す(QRチェックが日程表に出ない不具合の本体)。変化が無ければ据え置き。
+                const reflected = reflectParentOwnedSubmissionFields(existing, entry)
+                if (!reflected) return session
+                reflectedParentFields = true
+                return {
+                  ...session,
+                  studentInputs: {
+                    ...session.studentInputs,
+                    [entry.personId]: { ...existing, ...reflected, updatedAt: now },
+                  },
+                  updatedAt: now,
+                }
+              }
               newlyAppliedEntries.push(entry)
               return {
                 ...session,
@@ -3731,8 +3752,8 @@ function AuthenticatedApp() {
             }
           })
         }
-        // 新規反映が無ければ参照を維持し、不要な再描画・配列確保を避ける。
-        return newlyAppliedEntries.length > 0 ? updated : current
+        // 新規反映(登録)または保護者所有フィールドの反映が無ければ参照を維持し、不要な再描画を避ける。
+        return newlyAppliedEntries.length > 0 || reflectedParentFields ? updated : current
       })
 
       // Trigger board placement for newly submitted teachers (same as schedule-teacher-count-save handler)

--- a/src/utils/submissionReflection.test.ts
+++ b/src/utils/submissionReflection.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { reflectParentOwnedSubmissionFields } from './submissionReflection'
+
+describe('reflectParentOwnedSubmissionFields', () => {
+  it('登録済みでも保護者のQR optionChecks を反映する(空→{0,1})', () => {
+    // 回帰防止(本不具合の本体): 室長ローカルが空のまま、保護者がQRで {0,1} を提出した場合、
+    // これを反映しないと手動保存で関数のスナップショット統合値を上書きしQRチェックが消える。
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: {}, groupClassParticipation: {} },
+      { optionChecks: { '0': true, '1': true }, groupClassParticipation: {} },
+    )
+    expect(result).not.toBeNull()
+    expect(result?.optionChecks).toEqual({ '0': true, '1': true })
+    expect(result?.groupClassParticipation).toEqual({})
+  })
+
+  it('集団参加(groupClassParticipation)の更新も反映する', () => {
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: {}, groupClassParticipation: {} },
+      { optionChecks: {}, groupClassParticipation: { 集団理科: true } },
+    )
+    expect(result?.groupClassParticipation).toEqual({ 集団理科: true })
+  })
+
+  it('変化が無ければ null(再描画・dirty化を避ける)', () => {
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: { '0': true }, groupClassParticipation: { 集団社会: true } },
+      { optionChecks: { '0': true }, groupClassParticipation: { 集団社会: true } },
+    )
+    expect(result).toBeNull()
+  })
+
+  it('true キー集合が同じならキー順が違っても同値扱い(null)', () => {
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: { '0': true, '2': true } },
+      { optionChecks: { '2': true, '0': true } },
+    )
+    expect(result).toBeNull()
+  })
+
+  it('entry 側が欠落(undefined)なら既存を保全する', () => {
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: { '0': true }, groupClassParticipation: { 集団理科: true } },
+      {},
+    )
+    // 既存と同値＝変化なし＝null(保全)。
+    expect(result).toBeNull()
+  })
+
+  it('保護者がチェックを外した提出({}）は反映してクリアする', () => {
+    const result = reflectParentOwnedSubmissionFields(
+      { optionChecks: { '0': true } },
+      { optionChecks: {} },
+    )
+    expect(result).not.toBeNull()
+    expect(result?.optionChecks).toEqual({})
+  })
+})

--- a/src/utils/submissionReflection.ts
+++ b/src/utils/submissionReflection.ts
@@ -1,0 +1,48 @@
+// QR提出の取り込み(App.tsx の subscribeLectureSubmissions onSubmitted)で使う純関数。
+//
+// 背景: 生徒が既に登録済み(countSubmitted=true)だと、onSubmitted は届いた提出を丸ごとスキップ
+// していた。しかし optionChecks / groupClassParticipation は「保護者が QR で決める＝常に最新の
+// 提出値を反映すべき」フィールドで、これを握りつぶすと、室長アプリのローカル状態が古いまま
+// 手動保存され、Cloud Function がスナップショットへ統合した正しい提出値を空で上書きして消す
+// (実例: 岩佐s085 のQR optionChecks {0,1} がスナップショットで {} に消失)。
+//
+// そこで登録済みでも「保護者所有の2フィールドだけ」は最新提出値を反映する。回数・配置・出席不可
+// 等の再実行はしない(既存ガードの意図＝重複適用や室長編集の保護は維持)。
+
+type BoolMap = Record<string, boolean>
+
+// true のキー集合を正規化した署名。提出値は true のみ保持(関数側 sanitize 済み)のため、
+// true キー集合が一致すれば実質同値とみなせる。
+function trueKeySignature(map: BoolMap | undefined): string {
+  if (!map) return ''
+  return Object.keys(map)
+    .filter((key) => map[key] === true)
+    .sort()
+    .join(',')
+}
+
+export type ParentOwnedSubmissionFields = {
+  optionChecks?: BoolMap
+  groupClassParticipation?: BoolMap
+}
+
+/**
+ * 登録済み(countSubmitted)生徒に対し、保護者所有フィールド(optionChecks /
+ * groupClassParticipation)の最新提出値を算出する。
+ * 変化が無ければ null を返す(不要な再描画・dirty 化を避けるため)。
+ * 変化があれば反映すべき値を返す(呼び出し側で既存 input に展開する)。
+ */
+export function reflectParentOwnedSubmissionFields(
+  existing: ParentOwnedSubmissionFields,
+  entry: ParentOwnedSubmissionFields,
+): { optionChecks: BoolMap; groupClassParticipation: BoolMap } | null {
+  // entry 側は購読で常に定義済み(未設定でも {})。提出値を正としつつ、欠落時は既存を保全。
+  const nextOptionChecks = entry.optionChecks ?? existing.optionChecks ?? {}
+  const nextGroupParticipation = entry.groupClassParticipation ?? existing.groupClassParticipation ?? {}
+
+  const optionChanged = trueKeySignature(existing.optionChecks) !== trueKeySignature(nextOptionChecks)
+  const groupChanged = trueKeySignature(existing.groupClassParticipation) !== trueKeySignature(nextGroupParticipation)
+  if (!optionChanged && !groupChanged) return null
+
+  return { optionChecks: nextOptionChecks, groupClassParticipation: nextGroupParticipation }
+}


### PR DESCRIPTION
## 症状
QRスマホ画面でオプションにチェックして提出しても、生徒日程表に反映されない（残課題①の往復・後半）。

## 原因（本番実データで確認）
岩佐(`s085`)のQR提出ドキュメントは `optionChecks:{0:true,1:true}`（保存OK）なのに、教室スナップショットでは `optionChecks:{}`・`countSubmitted:true`（室長が手動保存した状態）。

購読取り込み `App.tsx onSubmitted` が、生徒が既に `countSubmitted=true` だと届いた提出を**丸ごとスキップ**（`if (existing?.countSubmitted) return session`）していた。`optionChecks` / `groupClassParticipation` は保護者がQRで決める「常に最新を反映すべき」フィールドなのに握りつぶされ、室長ローカルが古いまま手動保存 → Cloud Function がスナップショットへ統合した正しい提出値を**空で上書きして消す**。

## 修正
- 純関数 `reflectParentOwnedSubmissionFields`（`src/utils/submissionReflection.ts`）を追加。登録済みでも**保護者所有の2フィールドだけ**最新提出値を反映（回数・配置は再実行しない＝既存ガードの意図は維持）。変化が無ければ据え置き（不要な再描画/dirty化を回避）。
- `onSubmitted` から使用。`reflectedParentFields` フラグで state 更新を確定。
- **自己修復**: アプリ再読込時の初回購読で、既に消えてしまった分も doc の値から復元される。

## テスト
- 回帰防止テスト6件追加（空→{0,1}反映 / 集団参加反映 / 同値はnull / キー順非依存 / entry欠落は保全 / チェック解除の反映）。
- `test:unit` **384 緑**、build・型チェックOK。開発用教室のみ有効。

🤖 Generated with [Claude Code](https://claude.com/claude-code)