### PR TITLE
style(生徒日程表): 振替授業欄を狭め連絡事項を広げ、連絡事項文字を2px小さく

### DIFF
--- a/src/utils/scheduleHtml.ts
+++ b/src/utils/scheduleHtml.ts
@@ -1877,9 +1877,15 @@ function createScheduleHtml(payload: SchedulePayload, viewType: 'student' | 'tea
         grid-template-columns: minmax(0, 1.5fr) 206px 246px;
       }
 
-      /* オプション欄あり: 休み欄(168px)を削除し、振替授業を左へ、空いた所にオプション欄を置く。 */
+      /* オプション欄あり: 休み欄(168px)を削除し、振替授業を左へ、空いた所にオプション欄を置く。
+         振替授業欄は従来比4/5(206→165px)に狭め、空いた分は可変幅の連絡事項2列が吸収して広がる。 */
       .bottom-grid.bottom-grid-option {
-        grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.35fr) 206px 190px 246px;
+        grid-template-columns: minmax(0, 1.35fr) minmax(0, 1.35fr) 165px 190px 246px;
+      }
+
+      /* オプション欄あり: 連絡事項(共通/個別)のテキストは周囲より2px小さく表示する。 */
+      .bottom-grid.bottom-grid-option .box-textarea {
+        font-size: calc(1em - 2px);
       }
 
       .box-panel {


### PR DESCRIPTION
開発用教室のオプション欄レイアウト(`bottom-grid-option`)のみ調整。本番教室の表示には影響なし。

- 振替授業欄: `206px → 165px`(従来比4/5)。空いた分は可変幅(`fr`)の共通/個別連絡事項2列が自動で吸収して広がる。
- 連絡事項(共通/個別)のテキスト: 周囲より2px小さく(`font-size: calc(1em - 2px)`)。

レイアウトのみ。scheduleHtml.test 44緑・build OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)